### PR TITLE
textscan BufSize option has been obsoleted

### DIFF
--- a/NetCDF/templateType.m
+++ b/NetCDF/templateType.m
@@ -141,7 +141,11 @@ function lines = readTemplate(filepath)
 
         if fid == -1, error(['could not open file ' filepath]); end
 
-        lines = textscan(fid, '%s', 'Delimiter', '', 'CommentStyle', '%', 'BufSize', 12000);
+        if verLessThan('matlab', '8.4')
+            lines = textscan(fid, '%s', 'Delimiter', '', 'CommentStyle', '%', 'BufSize', 12000);
+        else
+            lines = textscan(fid, '%s', 'Delimiter', '', 'CommentStyle', '%');
+        end
         lines = lines{1};
 
         fclose(fid);

--- a/NetCDF/templateType.m
+++ b/NetCDF/templateType.m
@@ -141,11 +141,7 @@ function lines = readTemplate(filepath)
 
         if fid == -1, error(['could not open file ' filepath]); end
 
-        if verLessThan('matlab', '8.4')
-            lines = textscan(fid, '%s', 'Delimiter', '', 'CommentStyle', '%', 'BufSize', 12000);
-        else
-            lines = textscan(fid, '%s', 'Delimiter', '', 'CommentStyle', '%');
-        end
+        lines = textscan(fid, '%s', 'Delimiter', '', 'CommentStyle', '%');
         lines = lines{1};
 
         fclose(fid);


### PR DESCRIPTION
At least from R2015b the BufSize option has been removed from textscan. Have chosen R2014b as a convenient cutoff (introduction of HG2). Don't know if this was important for performance in version <R2014b so have kept original call for <R2014b.