### PR TITLE
textscan BufSize option has been obsoleted

### DIFF
--- a/NetCDF/templateType.m
+++ b/NetCDF/templateType.m
@@ -141,7 +141,7 @@ function lines = readTemplate(filepath)
 
         if fid == -1, error(['could not open file ' filepath]); end
 
-        lines = textscan(fid, '%s', 'Delimiter', '', 'CommentStyle', '%', 'BufSize', 12000);
+        lines = textscan(fid, '%s', 'Delimiter', '', 'CommentStyle', '%');
         lines = lines{1};
 
         fclose(fid);


### PR DESCRIPTION
The BufSize option to textscan has been obsoleted in R2015b. As this function is reading in relatively small template files it should not be necessary for performance and so can be removed for all Matlab versions.