### PR TITLE
Flow manager fix

### DIFF
--- a/FlowManager/flowManager.m
+++ b/FlowManager/flowManager.m
@@ -56,8 +56,8 @@ function flowManager(toolboxVersion)
   for k = 1:length(nonUTCRawData), nonUTCRawData{k}.meta.index = k; end
   
   % preprocess data
-  rawData       = preprocessManager(nonUTCRawData, 'raw', mode, false); % only apply TIME to UTC pre-processing routines
-  autoQCData    = preprocessManager(nonUTCRawData, 'qc',  mode, true);  % auto is true so that GUI only appears once
+  rawData       = preprocessManager(nonUTCRawData, 'raw', mode, false); % only apply TIME to UTC conversion pre-processing routines
+  autoQCData    = preprocessManager(rawData, 'qc',  mode, true);  % apply any pp routine except TIME to UTC conversion, auto is true so that GUI only appears once
   clear nonUTCRawData;
   
   % display data

--- a/Preprocessing/CTDDepthBinPP.m
+++ b/Preprocessing/CTDDepthBinPP.m
@@ -54,6 +54,8 @@ if isempty(sample_data), return;                                    end
 % auto logical in input to enable running under batch processing
 if nargin<3, auto=false; end
 
+% no modification of data is performed on the raw FV00 dataset except
+% local time to UTC conversion
 if strcmpi(qcLevel, 'raw'), return; end
 
 % read options from parameter file  Minimum Soak Delay: SoakDelay1 (sec.)

--- a/Preprocessing/aquatrackaPP.m
+++ b/Preprocessing/aquatrackaPP.m
@@ -51,6 +51,8 @@ error(nargchk(2, 3, nargin));
 if ~iscell(sample_data), error('sample_data must be a cell array'); end
 if isempty(sample_data), return;                                    end
 
+% no modification of data is performed on the raw FV00 dataset except
+% local time to UTC conversion
 if strcmpi(qcLevel, 'raw'), return; end
 
 % auto logical in input to enable running under batch processing

--- a/Preprocessing/binMappingVelocityPP.m
+++ b/Preprocessing/binMappingVelocityPP.m
@@ -60,6 +60,8 @@ if isempty(sample_data), return;                                    end
 % auto logical in input to enable running under batch processing
 if nargin<3, auto=false; end
 
+% no modification of data is performed on the raw FV00 dataset except
+% local time to UTC conversion
 if strcmpi(qcLevel, 'raw'), return; end
 
 for k = 1:length(sample_data)

--- a/Preprocessing/depthPP.m
+++ b/Preprocessing/depthPP.m
@@ -62,6 +62,8 @@ if isempty(sample_data), return;                                    end
 % auto logical in input to enable running under batch processing
 if nargin<3, auto=false; end
 
+% no modification of data is performed on the raw FV00 dataset except
+% local time to UTC conversion
 if strcmpi(qcLevel, 'raw'), return; end
 
 % read options from parameter file

--- a/Preprocessing/magneticDeclinationPP.m
+++ b/Preprocessing/magneticDeclinationPP.m
@@ -55,6 +55,8 @@ function sample_data = magneticDeclinationPP( sample_data, qcLevel, auto )
   if ~iscell(sample_data), error('sample_data must be a cell array'); end
   if isempty(sample_data), return;                                    end
   
+  % no modification of data is performed on the raw FV00 dataset except
+  % local time to UTC conversion
   if strcmpi(qcLevel, 'raw'), return; end
   
   switch computer

--- a/Preprocessing/pressureRelPP.m
+++ b/Preprocessing/pressureRelPP.m
@@ -51,6 +51,8 @@ if isempty(sample_data), return;                                    end
 % auto logical in input to enable running under batch processing
 if nargin<3, auto=false; end
 
+% no modification of data is performed on the raw FV00 dataset except
+% local time to UTC conversion
 if strcmpi(qcLevel, 'raw'), return; end
 
 pressureRelFile = ['Preprocessing' filesep 'pressureRelPP.txt'];

--- a/Preprocessing/rdiBinMappingVelocityPP.m
+++ b/Preprocessing/rdiBinMappingVelocityPP.m
@@ -57,6 +57,8 @@ if isempty(sample_data), return;                                    end
 % auto logical in input to enable running under batch processing
 if nargin<3, auto=false; end
 
+% no modification of data is performed on the raw FV00 dataset except
+% local time to UTC conversion
 if strcmpi(qcLevel, 'raw'), return; end
 
 for k = 1:length(sample_data)

--- a/Preprocessing/rinkoDoPP.m
+++ b/Preprocessing/rinkoDoPP.m
@@ -51,6 +51,8 @@ error(nargchk(2, 3, nargin));
 if ~iscell(sample_data), error('sample_data must be a cell array'); end
 if isempty(sample_data), return;                                    end
 
+% no modification of data is performed on the raw FV00 dataset except
+% local time to UTC conversion
 if strcmpi(qcLevel, 'raw'), return; end
 
 % auto logical in input to enable running under batch processing

--- a/Preprocessing/salinityPP.m
+++ b/Preprocessing/salinityPP.m
@@ -56,6 +56,8 @@ error(nargchk(2, 3, nargin));
 if ~iscell(sample_data), error('sample_data must be a cell array'); end
 if isempty(sample_data), return;                                    end
 
+% no modification of data is performed on the raw FV00 dataset except
+% local time to UTC conversion
 if strcmpi(qcLevel, 'raw'), return; end
 
 % auto logical in input to enable running under batch processing

--- a/Preprocessing/soakStatusPP.m
+++ b/Preprocessing/soakStatusPP.m
@@ -66,6 +66,8 @@ if isempty(sample_data), return;                                    end
 % auto logical in input to enable running under batch processing
 if nargin<3, auto=false; end
 
+% no modification of data is performed on the raw FV00 dataset except
+% local time to UTC conversion
 if strcmpi(qcLevel, 'raw'), return; end
 
 % read options from parameter file  Minimum Soak Delay: SoakDelay1 (sec.)

--- a/Preprocessing/timeMetaOffsetPP.m
+++ b/Preprocessing/timeMetaOffsetPP.m
@@ -62,6 +62,10 @@ function sample_data = timeMetaOffsetPP(sample_data, qcLevel, auto)
   
   % auto logical in input to enable running under batch processing
   if nargin<3, auto=false; end
+  
+  % time offsets are already performed on raw FV00 dataset which then go through
+  % this pp to generate the qc'd FV01 dataset.
+  if strcmpi(qcLevel, 'qc'), return; end
       
   offsetFile = ['Preprocessing' filesep 'timeOffsetPP.txt'];
 

--- a/Preprocessing/timeOffsetPP.m
+++ b/Preprocessing/timeOffsetPP.m
@@ -64,7 +64,11 @@ function sample_data = timeOffsetPP(sample_data, qcLevel, auto)
   
   % auto logical in input to enable running under batch processing
   if nargin<3, auto=false; end
-      
+
+  % time offsets are already performed on raw FV00 dataset which then go through
+  % this pp to generate the qc'd FV01 dataset.
+  if strcmpi(qcLevel, 'qc'), return; end
+  
   offsetFile = ['Preprocessing' filesep 'timeOffsetPP.txt'];
 
   descs     = {};

--- a/Preprocessing/timeStartPP.m
+++ b/Preprocessing/timeStartPP.m
@@ -56,6 +56,8 @@ function sample_data = timeStartPP( sample_data, qcLevel, auto )
   if nargin<3, auto=false; end
   if auto, error('timeStart pre-processing cannot be ran in batch mode'); end
   
+  % no modification of data is performed on the raw FV00 dataset except
+  % local time to UTC conversion
   if strcmpi(qcLevel, 'raw'), return; end
   
   timeFmt = readProperty('toolbox.timeFormat');

--- a/Preprocessing/transformPP.m
+++ b/Preprocessing/transformPP.m
@@ -75,6 +75,8 @@ function sample_data = transformPP( sample_data, qcLevel, auto )
   % auto logical in input to enable running under batch processing
   if nargin<3, auto=false; end
   
+  % no modification of data is performed on the raw FV00 dataset except
+  % local time to UTC conversion
   if strcmpi(qcLevel, 'raw'), return; end
   
   % generate descriptions for each data set

--- a/Preprocessing/variableOffsetPP.m
+++ b/Preprocessing/variableOffsetPP.m
@@ -58,6 +58,8 @@ function sample_data = variableOffsetPP( sample_data, qcLevel, auto )
   % auto logical in input to enable running under batch processing
   if nargin<3, auto=false; end
   
+  % no modification of data is performed on the raw FV00 dataset except
+  % local time to UTC conversion
   if strcmpi(qcLevel, 'raw'), return; end
   
   % generate descriptions for each data set


### PR DESCRIPTION
Originally submitted by @BecCowley :

Change FlowManager to use rawData (instead of nonUTCRawData) when applying any time PP routines to create autoQCData structure. This means that the time PP routines that are applied to the rawData are carried through to autoQCData. Previously, the timeOffsetPP routine reset the offsets to zero when run the second time.

Supersedes https://github.com/aodn/imos-toolbox/pull/266