### PR TITLE
Remove hardwired TIME dimension id access.

### DIFF
--- a/Graph/TimeSeries/flagTimeSeriesGeneric.m
+++ b/Graph/TimeSeries/flagTimeSeriesGeneric.m
@@ -57,8 +57,8 @@ if ~isnumeric(var),        error('var must be numeric');          end
 qcSet = str2double(readProperty('toolbox.qc_set'));
 rawFlag = imosQCFlag('raw', qcSet, 'flag');
 
-time = sample_data.variables{var}.dimensions(1);
-time = sample_data.dimensions{time};
+iTimeDim = getVar(sample_data.dimensions, 'TIME');
+time = sample_data.dimensions{iTimeDim};
 
 dim   = time.data;
 fl    = sample_data.variables{var}.flags;

--- a/Graph/TimeSeries/flagTimeSeriesTimeDepth.m
+++ b/Graph/TimeSeries/flagTimeSeriesTimeDepth.m
@@ -56,10 +56,10 @@ if ~isnumeric(var),        error('var must be numeric');          end
 qcSet = str2double(readProperty('toolbox.qc_set'));
 rawFlag = imosQCFlag('raw', qcSet, 'flag');
 
-time  = sample_data.variables{var}.dimensions(1);
+iTimeDim = getVar(sample_data.dimensions, 'TIME');
 depth = sample_data.variables{var}.dimensions(2);
 
-time  = sample_data.dimensions{time};
+time  = sample_data.dimensions{iTimeDim};
 depth = sample_data.dimensions{depth};
 
 fl    = sample_data.variables{var}.flags;

--- a/Graph/TimeSeries/flagTimeSeriesTimeFrequency.m
+++ b/Graph/TimeSeries/flagTimeSeriesTimeFrequency.m
@@ -56,10 +56,10 @@ if ~isnumeric(var),        error('var must be numeric');          end
 qcSet = str2double(readProperty('toolbox.qc_set'));
 rawFlag = imosQCFlag('raw', qcSet, 'flag');
 
-time  = sample_data.variables{var}.dimensions(1);
+iTimeDim = getVar(sample_data.dimensions, 'TIME');
 freq  = sample_data.variables{var}.dimensions(2);
 
-time = sample_data.dimensions{time};
+time = sample_data.dimensions{iTimeDim};
 freq = sample_data.dimensions{freq};
 
 fl    = sample_data.variables{var}.flags;

--- a/Graph/TimeSeries/getSelectedTimeSeriesGeneric.m
+++ b/Graph/TimeSeries/getSelectedTimeSeriesGeneric.m
@@ -54,8 +54,8 @@ if ~isnumeric(var),        error('var must be numeric');                 end
 if ~ishandle(ax),          error('ax must be a graphics handle');        end
 if ~ishandle(highlight),   error('highlight must be a graphics handle'); end
 
-time = sample_data.variables{var}.dimensions(1);
-time = sample_data.dimensions{time};
+iTimeDim = getVar(sample_data.dimensions, 'TIME');
+time = sample_data.dimensions{iTimeDim};
 
 highlightX = get(highlight, 'XData');
 

--- a/Graph/TimeSeries/getSelectedTimeSeriesTimeDepth.m
+++ b/Graph/TimeSeries/getSelectedTimeSeriesTimeDepth.m
@@ -55,10 +55,10 @@ if ~ishandle(highlight),   error('highlight must be a graphics handle'); end
 
 dataIdx = [];
 
-time  = sample_data.variables{var}.dimensions(1);
+iTimeDim = getVar(sample_data.dimensions, 'TIME');
 depth = sample_data.variables{var}.dimensions(2);
 
-time  = sample_data.dimensions{time} .data;
+time  = sample_data.dimensions{iTimeDim} .data;
 depth = sample_data.dimensions{depth}.data;
 
 highlightX = get(highlight, 'XData');

--- a/Graph/TimeSeries/getSelectedTimeSeriesTimeFrequency.m
+++ b/Graph/TimeSeries/getSelectedTimeSeriesTimeFrequency.m
@@ -55,10 +55,10 @@ if ~ishandle(highlight),   error('highlight must be a graphics handle'); end
 
 dataIdx = [];
 
-time = sample_data.variables{var}.dimensions(1);
+iTimeDim = getVar(sample_data.dimensions, 'TIME');
 freq = sample_data.variables{var}.dimensions(4);
 
-time = sample_data.dimensions{time}.data;
+time = sample_data.dimensions{iTimeDim}.data;
 freq = sample_data.dimensions{freq}.data;
 
 highlightX = get(highlight, 'XData');

--- a/Graph/TimeSeries/graphTimeSeriesGeneric.m
+++ b/Graph/TimeSeries/graphTimeSeriesGeneric.m
@@ -54,9 +54,9 @@ if ~isstruct(sample_data), error('sample_data must be a struct'); end
 if ~isnumeric(var),        error('var must be a numeric');        end
 if ~isvector(color),       error('color must be a vector');       end
 
-time = sample_data.variables{var}.dimensions(1);
+iTimeDim = getVar(sample_data.dimensions, 'TIME');
 
-time = sample_data.dimensions{time};
+time = sample_data.dimensions{iTimeDim};
 var  = sample_data.variables {var};
 
 if ischar(var.data), var.data = str2num(var.data); end % we assume data is an array of one single character

--- a/Graph/TimeSeries/graphTimeSeriesTimeDepth.m
+++ b/Graph/TimeSeries/graphTimeSeriesTimeDepth.m
@@ -55,10 +55,10 @@ if ~ishandle(ax),          error('ax must be a graphics handle'); end
 if ~isstruct(sample_data), error('sample_data must be a struct'); end
 if ~isnumeric(var),        error('var must be a numeric');        end
 
-time  = sample_data.variables{var}.dimensions(1);
+iTimeDim = getVar(sample_data.dimensions, 'TIME');
 depth = sample_data.variables{var}.dimensions(2);
 
-time  = sample_data.dimensions{time};
+time  = sample_data.dimensions{iTimeDim};
 depth = sample_data.dimensions{depth};
 var   = sample_data.variables {var};
 

--- a/Graph/TimeSeries/graphTimeSeriesTimeFrequency.m
+++ b/Graph/TimeSeries/graphTimeSeriesTimeFrequency.m
@@ -55,10 +55,10 @@ if ~ishandle(ax),          error('ax must be a graphics handle'); end
 if ~isstruct(sample_data), error('sample_data must be a struct'); end
 if ~isnumeric(var),        error('var must be a numeric');        end
 
-time = sample_data.variables{var}.dimensions(1);
+iTimeDim = getVar(sample_data.dimensions, 'TIME');
 freq = sample_data.variables{var}.dimensions(2);
 
-time = sample_data.dimensions{time};
+time = sample_data.dimensions{iTimeDim};
 freq = sample_data.dimensions{freq};
 var  = sample_data.variables {var};
 

--- a/Graph/TimeSeries/graphTimeSeriesTimeFrequencyDirection.m
+++ b/Graph/TimeSeries/graphTimeSeriesTimeFrequencyDirection.m
@@ -61,11 +61,11 @@ end
 
 function [h, labels] = polarPcolor(ax, sample_data, var)
 
-time = sample_data.variables{var}.dimensions(1);
+iTimeDim = getVar(sample_data.dimensions, 'TIME');
 freq = sample_data.variables{var}.dimensions(2);
 dir  = sample_data.variables{var}.dimensions(3);
 
-timeData  = sample_data.dimensions{time}.data;
+timeData  = sample_data.dimensions{iTimeDim}.data;
 dirData   = sample_data.dimensions{dir}.data;
 freqData  = sample_data.dimensions{freq}.data;
 sswvData  = sample_data.variables{var}.data;


### PR DESCRIPTION
Some of the graphing routines are grabbing the TIME dimension id directly from the variables dimension layout, is there a reason for this? Assuming there isn't below set of patches uses the standard getVar(sample_data.dimensions, 'TIME') syntax.

If this is ok, then there are cases of routines looking for frequency or direction related dimension eg flagTimeSeriesTimeFrequency.m that could be updated in a similar fashion.