### PR TITLE
Handle case where times from spectra are shorter than LOG9.txt wave data times.

### DIFF
--- a/Parser/readWorkhorseWaveAscii.m
+++ b/Parser/readWorkhorseWaveAscii.m
@@ -1,21 +1,21 @@
 function waveData = readWorkhorseWaveAscii( filename )
-%READWORKHORSEWAVEASCII Reads RDI Workhorse wave data from processed wave text files 
+%READWORKHORSEWAVEASCII Reads RDI Workhorse wave data from processed wave text files
 % (_LOG9.txt, DSpec*.txt, PSpec*.txt, SSpec*.txt and VSpec*.txt).
 %
 % Inspired from read_adcpWvs.m and read_adcpWvs_spec.m by Charlene Sullivan
 % csullivan@usgs.gov USGS Woods Hole Science Center.
 %
-% This function takes the name of a binnary RDI wave data file (.WVS) and 
+% This function takes the name of a binnary RDI wave data file (.WVS) and
 % from that name locates the log9 and spectra files (_LOG9.txt, DSpec*.txt,
 % PSpec*.txt, SSpec*.txt and VSpec*.txt). Those files can be obtained using
 % WavesMon RDI softwares (see http://pubs.usgs.gov/of/2005/1211/images/pdf/report.pdf).
-% It is assumed that these files are located in the same directory as the 
+% It is assumed that these files are located in the same directory as the
 % binary file and that the log9 file is named '*_LOG9.TXT'.
 %
 % This function currently assumes a number of things:
 %
 %   - That the ASCII files exist in the same directory as the binary file.
-%   - That the spectra files are named DSpec*.txt, PSpec*.txt, SSpec*.txt 
+%   - That the spectra files are named DSpec*.txt, PSpec*.txt, SSpec*.txt
 %   and VSpec*.txt with * being a date of format yyyymmddHHMM.
 %   - That the log file is of format 9 and with a name such as
 %   '*_LOG9.TXT'. See this URL below for more details on the format :
@@ -31,32 +31,32 @@ function waveData = readWorkhorseWaveAscii( filename )
 %
 
 %
-% Copyright (c) 2009, eMarine Information Infrastructure (eMII) and Integrated 
+% Copyright (c) 2009, eMarine Information Infrastructure (eMII) and Integrated
 % Marine Observing System (IMOS).
 % All rights reserved.
-% 
-% Redistribution and use in source and binary forms, with or without 
+%
+% Redistribution and use in source and binary forms, with or without
 % modification, are permitted provided that the following conditions are met:
-% 
-%     * Redistributions of source code must retain the above copyright notice, 
+%
+%     * Redistributions of source code must retain the above copyright notice,
 %       this list of conditions and the following disclaimer.
-%     * Redistributions in binary form must reproduce the above copyright 
-%       notice, this list of conditions and the following disclaimer in the 
+%     * Redistributions in binary form must reproduce the above copyright
+%       notice, this list of conditions and the following disclaimer in the
 %       documentation and/or other materials provided with the distribution.
-%     * Neither the name of the eMII/IMOS nor the names of its contributors 
-%       may be used to endorse or promote products derived from this software 
+%     * Neither the name of the eMII/IMOS nor the names of its contributors
+%       may be used to endorse or promote products derived from this software
 %       without specific prior written permission.
-% 
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 % POSSIBILITY OF SUCH DAMAGE.
 %
 narginchk(1, 1);
@@ -131,31 +131,31 @@ for s = 1:length(specType)
         switch specType{s}
             case 'D'
                 if n == 1
-                   % get some metadata that are the same through the
-                   % deployment
-                   fid = fopen(fullfile(filePath, filename), 'r');
-                   for i=1:2
-                       junk = fgetl(fid);
-                   end
-                   
-                   infoDim = fgetl(fid);
-                   
-                   junk = fgetl(fid);
-                   
-                   infoFreq = fgetl(fid);
-                   fclose(fid);
-                   clear junk
-                   
-                   infoDim = sscanf(infoDim', '%*s %d %*s %*s %d %*s');
-                   waveData.Dspec.nDir  = infoDim(1);
-                   waveData.Dspec.nFreq = infoDim(2);
-                       
-                   infoFreq = sscanf(infoFreq', '%*s %*s %*s %*s %f %*s %*s %*s %*s %*s %*s %*s %f');
-                   freqStep  = infoFreq(1);
-                   firstFreq = infoFreq(2);
-                   
-                   waveData.Dspec.freq = (firstFreq : freqStep : firstFreq + (waveData.Dspec.nFreq-1)*freqStep)';
-                   waveData.Dspec.dir = (0 : 360/waveData.Dspec.nDir : 360 - 360/waveData.Dspec.nDir)';
+                    % get some metadata that are the same through the
+                    % deployment
+                    fid = fopen(fullfile(filePath, filename), 'r');
+                    for i=1:2
+                        junk = fgetl(fid);
+                    end
+                    
+                    infoDim = fgetl(fid);
+                    
+                    junk = fgetl(fid);
+                    
+                    infoFreq = fgetl(fid);
+                    fclose(fid);
+                    clear junk
+                    
+                    infoDim = sscanf(infoDim', '%*s %d %*s %*s %d %*s');
+                    waveData.Dspec.nDir  = infoDim(1);
+                    waveData.Dspec.nFreq = infoDim(2);
+                    
+                    infoFreq = sscanf(infoFreq', '%*s %*s %*s %*s %f %*s %*s %*s %*s %*s %*s %*s %f');
+                    freqStep  = infoFreq(1);
+                    firstFreq = infoFreq(2);
+                    
+                    waveData.Dspec.freq = (firstFreq : freqStep : firstFreq + (waveData.Dspec.nFreq-1)*freqStep)';
+                    waveData.Dspec.dir = (0 : 360/waveData.Dspec.nDir : 360 - 360/waveData.Dspec.nDir)';
                 end
                 
                 % get the direction at which the first direction slice
@@ -170,7 +170,7 @@ for s = 1:length(specType)
                 fclose(fid);
                 
                 firstDirSlice = ...
-                       sscanf(infoDir', '%*s %*s %*s %*s %*s %*s %*s %d %*s');
+                    sscanf(infoDir', '%*s %*s %*s %*s %*s %*s %*s %d %*s');
                 
                 direction = (firstDirSlice : 360/waveData.Dspec.nDir : firstDirSlice + 360 - 360/waveData.Dspec.nDir)';
                 direction(direction >= 360) = direction(direction >= 360) - 360;
@@ -179,7 +179,7 @@ for s = 1:length(specType)
                 % for 0
                 iLastDir = direction == max(direction);
                 direction(end+1) = min(direction) - 360/waveData.Dspec.nDir;
-                   
+                
                 data = load(fullfile(filePath, filename), '-ascii');
                 data( data == 0 ) = nan;
                 data(:, end+1) = data(:, iLastDir);
@@ -201,4 +201,39 @@ for s = 1:length(specType)
         end
     end
 end
+
+% Test time lengths for spectra types, have cases where times from spectra
+% are different (currently always shorter) than LOG9.txt wave data times.
+nTimes = numel(waveData.param.time);
+specType = {'D', 'P', 'S', 'V'};
+for s = 1:length(specType)
+    specName = [specType{s} 'spec'];
+    nSpecTime = numel(waveData.(specName).time);
+    if nSpecTime < nTimes
+        % spectra time shorter than LOG9.txt wave data times
+        % typically missing the last record, but to cover all possibilities 
+        % copy data from spectra times to matched LOG9 time.
+        disp(['Fixing short ' specName ' time.']);
+        [tf loc]=ismember(waveData.(specName).time, waveData.param.time);
+        % index locations for real numbers with tolerance
+        %[tf loc]=ismember(waveData.(specName).time, waveData.param.time, 'tol',1e-4);
+        oldData = waveData.(specName).data;
+        oldTime = waveData.(specName).time;
+        sizeOldData = size(oldData);
+        waveData.(specName).time = waveData.param.time;
+        waveData.(specName).data = NaN([nTimes sizeOldData(2:end)]);
+        newdataLoc = repmat(loc, [1 sizeOldData(2:end)]);
+        waveData.(specName).data(newdataLoc) = oldData;
+        clear('oldData');
+        clear('oldTime');
+        clear('newdataLoc');
+    else
+        % spectra time longer than LOG9.txt wave data times
+        % never had this happen, but for completeness warn user. If this
+        % happens then will need to decide what to do.
+        disp(['Fixing long ' specName ' time.']);
+        warning([[specType{s} 'spec'] ' time is greater than LOG9.txt time.']);
+    end
+end
+
 end


### PR DESCRIPTION
Have had a case where instrument problems create multiple PD0 files and after concatenating/renumbering and processing the resultant spectra times are shorter than LOG9.txt wave data times. Typically missing the last record, but to cover all possibilities copy data from spectra times to matched LOG9 time.

I have never had a case where spectra times are longerthan LOG9.txt wave data times so just issue a warning. If this should occur then will need to revisit that part of the code.

And it looks like my Matlab smart indent has created some whitespace shifts, sorry, don't know how to create diff against master branch ignoring this.