### PR TITLE
Change startTime/castDate logic in Seabird CNV file

### DIFF
--- a/Parser/readSBE19cnv.m
+++ b/Parser/readSBE19cnv.m
@@ -147,10 +147,13 @@ function [name, data, comment] = convertData(name, data, instHeader, procHeader,
 
   % the cast date, if present, is used for time field offset
   castDate = 0;
-  if isfield(instHeader, 'castDate')
-      castDate = instHeader.castDate;
+  if isfield(procHeader, 'startTime')
+    castDate = procHeader.startTime;
+  elseif isfield(instHeader, 'castDate')
+    castDate = instHeader.castDate;
+    if numel(castDate) > 1, castDate = castDate(1); end
   else
-      if isfield(procHeader, 'startTime'), castDate = procHeader.startTime; end
+    warning('No startTime/castDate found in Seabird CNV file.');
   end
   
   [name, data, comment] = convertSBEcnvVar(name, data, castDate, instHeader, procHeader, mode);


### PR DESCRIPTION
For converted CNV from SBE16plus (header extract below), the regexp used to find castDate in SBE19Parse results in multiple values. For the purpose of convertSBEcnvVar, timeOffset (passed in as castDate) has to be a scalar. Changed logic to first try startTime, then castDate and if multiple the choose the first one. This works for 'timeseries' data, but don't know if has any effect on 'profile' data, but logic could be further modified dependent on mode if required.


* hdr   1 07 Aug 2012 00:59:51 samples 1 to 2000, int = 600, stop = logging
* hdr   2 20 Aug 2012 22:20:13 samples 2001 to 4000, int = 600, stop = logging
* hdr   3 03 Sep 2012 19:40:13 samples 4001 to 6000, int = 600, stop = logging
* hdr   4 17 Sep 2012 17:00:13 samples 6001 to 8000, int = 600, stop = logging
* hdr   5 01 Oct 2012 14:20:13 samples 8001 to 10000, int = 600, stop = logging
* hdr   6 15 Oct 2012 11:40:13 samples 10001 to 12000, int = 600, stop = logging
* hdr   7 29 Oct 2012 09:00:13 samples 12001 to 14000, int = 600, stop = logging
* hdr   8 12 Nov 2012 06:20:13 samples 14001 to 16000, int = 600, stop = logging
* hdr   9 26 Nov 2012 03:40:13 samples 16001 to 18000, int = 600, stop = logging
* hdr  10 10 Dec 2012 01:00:13 samples 18001 to 20000, int = 600, stop = logging
* hdr  11 23 Dec 2012 22:20:13 samples 20001 to 22000, int = 600, stop = logging
* hdr  12 06 Jan 2013 19:40:13 samples 22001 to 24000, int = 600, stop = logging
* hdr  13 20 Jan 2013 17:00:13 samples 24001 to 24968, int = 600, stop = stop cmd
# nquan = 8
# nvalues = 24968                                 
# units = specified
# name 0 = timeS: Time, Elapsed [seconds]
# name 1 = prdM: Pressure, Strain Gauge [db]
# name 2 = tv290C: Temperature [ITS-90, deg C]
# name 3 = c0S/m: Conductivity [S/m]
# name 4 = flECO-AFL: Fluorescence, WET Labs ECO-AFL/FL [mg/m^3]
# name 5 = par: PAR/Irradiance, Biospherical/Licor
# name 6 = turbWETntu0: Turbidity, WET Labs ECO [NTU]
# name 7 = flag:  0.000e+00
# span 0 =      0.000, 14980200.0                 
# span 1 =     -0.109,     33.968                 
# span 2 =    23.4363,    32.7363                 
# span 3 =  -0.000002,   6.185809                 
# span 4 =    -0.0375,    64.0530                 
# span 5 = 4.5004e-02, 1.9477e+03                 
# span 6 =    -0.1513,   325.9143                 
# span 7 = 0.0000e+00, 0.0000e+00                 
# interval = seconds: 600
# start_time = Aug 07 2012 00:59:52 [Instrument's time stamp, first data scan]