### PR TITLE
Promote both xdata/ydata to type double in pcolor call for time-varia…

### DIFF
--- a/Graph/TimeSeries/graphTimeSeriesTimeDepth.m
+++ b/Graph/TimeSeries/graphTimeSeriesTimeDepth.m
@@ -70,7 +70,7 @@ yPcolor = depth.data;
 % xPcolor = [time.data(1:end-1) - diff(time.data)/2; time.data(end) - (time.data(end)-time.data(end-1))/2];
 % yPcolor = [depth.data(1:end-1) - diff(depth.data)/2; depth.data(end) - (depth.data(end)-depth.data(end-1))/2];
 
-h = pcolor(ax, xPcolor, yPcolor, double(var.data'));
+h = pcolor(ax, double(xPcolor), double(yPcolor), double(var.data'));
 set(h, 'FaceColor', 'flat', 'EdgeColor', 'none');
 cb = colorbar();
 

--- a/Graph/TimeSeries/graphTimeSeriesTimeFrequency.m
+++ b/Graph/TimeSeries/graphTimeSeriesTimeFrequency.m
@@ -70,7 +70,7 @@ yPcolor = freq.data;
 % xPcolor = [time.data(1:end-1) - diff(time.data)/2; time.data(end) - (time.data(end)-time.data(end-1))/2];
 % yPcolor = [freq.data(1:end-1) - diff(freq.data)/2; freq.data(end) - (freq.data(end)-freq.data(end-1))/2];
 
-h = pcolor(ax, xPcolor, yPcolor, double(var.data'));
+h = pcolor(ax, double(xPcolor), double(yPcolor), double(var.data'));
 set(h, 'FaceColor', 'flat', 'EdgeColor', 'none');
 cb = colorbar();
 


### PR DESCRIPTION
…ble plots. If you pass in type single for ydata to pcolor then both axis data types become single, which caused problems in R2016b for datestr trying to convert type single to a string.