### PR TITLE
Fix tooltip search string

### DIFF
--- a/GUI/mainWindow.m
+++ b/GUI/mainWindow.m
@@ -254,8 +254,8 @@ function mainWindow(...
   buttons = findall(tb);
   
   zoomoutb    = findobj(buttons, 'TooltipString', 'Zoom Out');
-  zoominb     = findobj(buttons, 'TooltipString', 'Zoom In (Ctrl+z)');
-  panb        = findobj(buttons, 'TooltipString', 'Pan (Ctrl+a)');
+  zoominb     = findobj(buttons, 'TooltipString', 'Zoom In');
+  panb        = findobj(buttons, 'TooltipString', 'Pan');
   datacursorb = findobj(buttons, 'TooltipString', 'Data Cursor');
   
   buttons(buttons == tb)            = [];


### PR DESCRIPTION
Not sure if this is an R2016b issue only, but the tool tip strings are 'Zoom In' and 'Pan', the ctrl short key text is never shown.