### PR TITLE
HG1/HG2 compatible graphics handle creation

### DIFF
--- a/Graph/lineCastVar.m
+++ b/Graph/lineCastVar.m
@@ -98,7 +98,7 @@ for k=1:lenVarNames
     hLineFlag = ones(4, 1);
     
     instrumentDesc{1} = 'Make Model (instrument SN - cast time)';
-    hLineVar(1) = 0;
+    hLineVar(1) = line(0,0,'Visible','off','LineStyle','none','Marker','none');
     
     for i=1:lenSampleData
         % instrument description


### PR DESCRIPTION
Make first entry in hLineVar an invisible line to create a HG1/HG2 compatible graphics handle. Setting a value of 0 when using HG2 caused legend call at line 293 to fail.