### PR TITLE
Fix variable name inferred from list of ticked boxes

### DIFF
--- a/GUI/mainWindow.m
+++ b/GUI/mainWindow.m
@@ -499,8 +499,9 @@ function mainWindow(...
                 userData = get(graphs1D(i), 'UserData');
                 hData = userData{1};
                 iTickBox = userData{2};
+                iAllTickedBox = find(cell2mat(get(hTickBoxes,'Value'))==1);
                 
-                varName = get(hTickBoxes(iTickBox), 'String');
+                varName = get(hTickBoxes(iAllTickedBox(iTickBox)), 'String');
                 iVar = getVar(sam.variables, varName);
                 flags = sam.variables{iVar}.flags;
                 iGood = ismember(flags, okFlags);


### PR DESCRIPTION
UserData returned is in the form {line{k}, k} i.e. handle to a line object and an index of the plot, so previous code hTickBoxes(iTickBox) would only be the iTickBox index into all check boxes, not index into currently ticked boxes.