### PR TITLE
Handle potential unlabelled last column in WQM dat file

### DIFF
--- a/Parser/readWQMdat.m
+++ b/Parser/readWQMdat.m
@@ -497,6 +497,9 @@ for k = 4:length(fields)
     end
 end
 
+% handle potential unlabelled last column
+format=strcat(format,'%*s');
+
 %remove unsupported fields from header list
 fields(unsupported) = [];
 end


### PR DESCRIPTION
For some WQM firwmare version and WQMhost software versions, can possibly have an extra unlabelled columen (a flag value?), eg

WQM	SN	MMDDYY	HHMMSS	Temp(C)	Pres(dbar)	Sal(PSU)	DO(ml/l)	CHL(ug/l)	NTU
WQM	135	060310	195934	23.62480	0.09000	0.01200	0.00000	-0.01400	0.76400	0.00000

Have only ever seen one extra column, and always as last column. Tested a two files with/without extra column.