### PR TITLE
Update flag resizing logic

### DIFF
--- a/AutomaticQC/imosInOutWaterQC.m
+++ b/AutomaticQC/imosInOutWaterQC.m
@@ -157,6 +157,5 @@ switch mode
         
         % transform flags to the appropriate output shape
         sizeData = size(data);
-        sizeData(sizeData == lenData) = 1;
-        flags = repmat(flags, sizeData);
+        flags = repmat(flags, [1 sizeData(2:end)]);
 end


### PR DESCRIPTION
You could be really unlucky and have a short file (say due to instrument failure) and the number of ensembles equals the number of bins (of even number of spectral elements for wave measurement) so that original logic would produce an incorrect input for repmat.