### PR TITLE
Handle Ruskin 1.13 date format change and update variable names.

### DIFF
--- a/Parser/readXR620.m
+++ b/Parser/readXR620.m
@@ -247,10 +247,10 @@ function sample_data = readXR620( filename, mode )
                       data.(vars{k}) = data.(vars{k})/10;
                       
                       %Temperature (Celsius degree)
-                  case {'Temp', 'temp02'}, name = 'TEMP';
+                  case {'Temp', 'temp02', 'temp12'}, name = 'TEMP';
                       
                       %Pressure (dBar)
-                  case {'Pres', 'pres20'}, name = 'PRES';
+                  case {'Pres', 'pres20', 'pres21'}, name = 'PRES';
                       
                       %Relative Pressure (dBar)
                   case {'pres08'}, name = 'PRES_REL';
@@ -514,7 +514,7 @@ function sample_data = readXR620( filename, mode )
                       data.(fields{k}) = data.(fields{k})/10;
                       
                       %Temperature (Celsius degree)
-                  case {'Temp', 'temp02'}, name = 'TEMP';
+                  case {'Temp', 'temp02', 'temp12'}, name = 'TEMP';
                       
                       %Pressure (dBar)
                   case {'Pres', 'pres08'}, name = 'PRES';
@@ -881,7 +881,11 @@ function data = readData(fid, header)
       if isempty(strfind(data.Date{1}, '-'))
           data.time = datenum(data.Date, 'yyyy/mmm/dd') + datenum(data.Time, 'HH:MM:SS.FFF') - datenum('00:00:00', 'HH:MM:SS');
       else
-          data.time = datenum(data.Date, 'dd-mmm-yyyy') + datenum(data.Time, 'HH:MM:SS.FFF') - datenum('00:00:00', 'HH:MM:SS');
+          % Ruskin version number <= 1.12 date format 'dd-mmm-yyyy'
+          % Ruskin version number 1.13 date format 'yyyy-mm-dd'
+          % can either do some simple date format test or see if datenum
+          % can figure it out
+          data.time = datenum(data.Date) + datenum(data.Time, 'HH:MM:SS.FFF') - datenum('00:00:00', 'HH:MM:SS');
       end
   end
   


### PR DESCRIPTION
Newer version of Ruskin has change date format and added some new variable names.

For reference Ruskin 1.12 (Model=TGR-2050)
             Date & Time         Temp          Pres         Depth 
21-Nov-2016 04:59:40.000    26.1610417    10.0852656    -0.0468489 

Ruskin 1.13 (RBRduet)
             Date & Time       temp12        pres21        slop00        pres08        dpth01 
2016-11-21 05:00:00.000   27.3160538    10.1018553          null    -0.0306447    -0.0303948 

Added 'temp12' and 'pres21' as required.

Method to handle data format is simply to not specify a format and let Matlab datenum try. Tested on dd-mmm-yyyy and yyyy-mm-dd data sucessfully.