### PR TITLE
Fix incorrect qcParam selection

### DIFF
--- a/Graph/TimeSeries/graphTimeSeriesGeneric.m
+++ b/Graph/TimeSeries/graphTimeSeriesGeneric.m
@@ -66,9 +66,8 @@ set(ax, 'Tag', 'axis1D');
 
 % for global/regional range and in/out water display
 mWh = findobj('Tag', 'mainWindow');
-sMh = findobj('Tag', 'samplePopUpMenu');
-iSample = get(sMh, 'Value');
 qcParam = get(mWh, 'UserData');
+iSample = find(arrayfun(@(x) strcmp(x.dataSet, sample_data.toolbox_input_file), qcParam));
 if ~isempty(qcParam)
     if isfield(qcParam, ['rangeMin' var.name])
         hold(ax, 'on');


### PR DESCRIPTION
Previous logic iSample obtained from list of filenames (equivalent to number of elements in sample_data structure) and this is used to index into qcParam. Elements in qcParam are only calculated (and each element uniquely identified) by filename. But some parsers can return  more than one structure (eg awacParse). So eg load awac file numel(sample_data) ==2, but numel(qcParam) == 1. Change logic to just find the index into qcParam using passed in sample_data.toolbox_input_file