### PR TITLE
Change returning imosToolbox('version') logic.

### DIFF
--- a/imosToolbox.m
+++ b/imosToolbox.m
@@ -48,7 +48,14 @@ function imosToolbox(auto, varargin)
 % POSSIBILITY OF SUCH DAMAGE.
 %
 
+% Set current toolbox version
+toolboxVersion = ['2.5.28 - ' computer];
+
 if nargin == 0, auto = 'manual'; end
+if nargin == 1 && strcmpi(auto, 'version')
+    disp(toolboxVersion);
+    return;
+end
 
 path = '';
 if ~isdeployed
@@ -73,11 +80,7 @@ for j = 1 : length(jars)
     javaaddpath(jars{j});
 end
 
-% Set current toolbox version
-toolboxVersion = ['2.5.28 - ' computer];
-
 switch auto  
   case 'auto',    autoIMOSToolbox(toolboxVersion, varargin{:});
-  case 'version', disp(toolboxVersion);
   otherwise,      flowManager(toolboxVersion);
 end


### PR DESCRIPTION
If user is only calling imosToolbox to get the version string don't bother setting paths etc.