### PR TITLE
Capture directional/compass offset from whr file

### DIFF
--- a/Parser/readAWACWaveAscii.m
+++ b/Parser/readAWACWaveAscii.m
@@ -186,6 +186,25 @@ try
     pwrFreq    = importdata(pwrFreqFile);
     pwrFreqDir = importdata(pwrFreqDirFile);
     
+    % need to check if during waves processing has had compass/directional
+    % offset applied
+    tkns = regexp(waveData.waveSummary,'(?i:Directional Offset\s+)(.*)(?i:\s+deg\s*)','tokens');
+    directionalOffset = str2num(tkns{~cellfun(@isempty,tkns)}{1}{1});
+    tkns = regexp(waveData.waveSummary,'(?i:Compass offset\s+)(.*)(?i:\s+deg\s*)','tokens');
+    compassOffset = str2num(tkns{~cellfun(@isempty,tkns)}{1}{1});
+    % have always assumed (and only observed) that in whr file, directionalOffset == compassOffset
+    if directionalOffset ~= compassOffset
+        throw(MException('readAWACWaveAscii:offsetError','Uncertain how to handle different directionalOffset and compassOffset'));
+    end
+    waveData.isMagBias = false;
+    waveData.magDec = directionalOffset;
+    if waveData.magDec ~= 0
+        waveData.isMagBias = true;
+        waveData.magBiasComment = ['A compass correction of ' num2str(magDec) ...
+            'degrees has been applied to the data during wave processing stage ' ...
+            '(usually to account for magnetic declination).'];
+    end
+
     % Transform local missing value (-9.00) to NaN
     wave(wave == -9.00) = NaN;
     dirFreq(dirFreq == -9.00) = NaN;


### PR DESCRIPTION
Dependent on PR [#469](https://github.com/aodn/imos-toolbox/pull/469) for import of whr file. Have followed simlar logic in workhorseParse.m in setting ```isMagBias```. Handling of parameters affected by this will have to be handled by the calling function.