### PR TITLE
Close ResultSets and Statements

### DIFF
--- a/Java/src/org/imos/ddb/JDBCDDB.java
+++ b/Java/src/org/imos/ddb/JDBCDDB.java
@@ -175,9 +175,14 @@ public class JDBCDDB extends DDB {
 				}
 			}
 		}
-
 		//always close db connection
-		finally {try {conn.close();} catch (Exception e) {}}
+		finally {
+			try {
+				rs.close();
+				stmt.close();
+				conn.close();
+			} 
+			catch (Exception e) {}}
 
 		return results;
 	}


### PR DESCRIPTION
Just noticed that JDBCDDB.java didn't close objects as per ODBCDDB.java