### PR TITLE
Add new 'prSM' pressure string identifier

### DIFF
--- a/Parser/convertSBEcnvVar.m
+++ b/Parser/convertSBEcnvVar.m
@@ -82,7 +82,7 @@ switch name
       comment = '';
         
     % strain gauge pressure (dbar)
-    case {'pr', 'prM', 'prdM'}
+    case {'pr', 'prM', 'prdM','prSM'}
       name = 'PRES_REL';
       comment = '';
       


### PR DESCRIPTION
Was processing an old SBE19 SEACAT PROFILER V2.1a file and came across another pressure string, namely

# name 2 = prSM: Pressure, Strain Gauge [db]