### PR TITLE
Add old SBE19 SEACAT PROFILER serial number format

### DIFF
--- a/Parser/SBE19Parse.m
+++ b/Parser/SBE19Parse.m
@@ -429,6 +429,7 @@ firmExpr2    = '^\*\s*FirmwareVersion:\s*(\S+)'; %SBE39plus
 sensorId     = '<Sensor id=''(.*\S+.*)''>';
 sensorType   = '<[tT]ype>(.*\S+.*)</[tT]ype>';
 serialExpr   = '^\*\s*SerialNumber:\s*(\S+)'; %SBE39plus
+serialExpr2  = '^\*\s*SEACAT PROFILER\s*V(\S+)\s*SN\s*(\S+)';
 
 exprs = {...
     headerExpr   headerExpr2    headerExpr3    scanExpr     ...
@@ -438,7 +439,7 @@ exprs = {...
     castExpr     castExpr2   intervalExpr ...
     sbe38Expr    optodeExpr   ...
     voltCalExpr  otherExpr ...
-    firmExpr     sensorId   sensorType firmExpr2 serialExpr};
+    firmExpr     sensorId   sensorType firmExpr2 serialExpr serialExpr2};
 
 for k = 1:length(headerLines)
     
@@ -593,6 +594,11 @@ for k = 1:length(headerLines)
                 case 25
                     header.instrument_serial_no = tkns{1}{1};
 
+                % old SEACAT PROFILER serial number format
+                % example "* SEACAT PROFILER V2.1a SN 597   10/15/11  10:02:56.721"
+                case 26
+                    % is tkns{1}{1} firmware version?
+                    header.instrument_serial_no = tkns{1}{2};
             end
             break;
         end


### PR DESCRIPTION
Was processing some old SBE19 SEACAT PROFILER v2.1a data and came across an unhandled serial number format. Header lines example

```
* Sea-Bird SBE19 Data File:
* FileName = C:\Users\OGTECHS\Desktop\Trip 5423\CTD\GB11077.hex
* Software Version 1.59
* Temperature SN = 597
* Conductivity SN = 597
* System UpLoad Time = Oct 15 2011 07:39:14
** GB11077
* ds
* SEACAT PROFILER V2.1a SN 597   10/15/11  07:37:55.484
* pressure sensor: serial no = 143864,  range = 150 psia,  tc = 151
* clk = 32767.609   iop = 210   vmain = 7.8   vlith = 5.4
* ncasts = 3   samples = 3083   free = 25794   lwait = 0 msec
* sample rate = 1 scan every 0.5 seconds
* battery cutoff = 5.8 volts
* number of voltages sampled = 2
* S>
* dh
* cast 1  10/15  05:41:06   samples 737 to 2397  stop = switch off
* S>
```