### PR TITLE
Set axis in colorbar contextmenu callback.

### DIFF
--- a/Graph/TimeSeries/graphTimeSeriesTimeDepth.m
+++ b/Graph/TimeSeries/graphTimeSeriesTimeDepth.m
@@ -76,14 +76,19 @@ posWithoutCb = get(ax, 'Position');
 
 h = pcolor(ax, double(xPcolor), double(yPcolor), double(var.data'));
 set(h, 'FaceColor', 'flat', 'EdgeColor', 'none');
-cb = colorbar('peer', ax);
+% 'peer' input is not recommended starting in R2014b
+if verLessThan('matlab', '8.4')
+    cb = colorbar('peer', ax);
+else
+    cb = colorbar(ax);
+end
 
 % reset position to what it was without the colorbar so that it aligns with
 % 1D datasets
 set(ax, 'Position', posWithoutCb);
 
 % Attach the context menu to colorbar
-hMenu = setTimeSerieColorbarContextMenu(var);
+hMenu = setTimeSerieColorbarContextMenu(ax, var);
 set(cb, 'uicontextmenu', hMenu);
 
 % Let's redefine properties after pcolor to make sure grid lines appear
@@ -96,7 +101,7 @@ set(ax, 'XTick',        xTickProp.ticks, ...
         'Layer',        'top', ...
         'Tag',          'axis2D');
 
-if all(all(colormap == rkbwr))
+if all(all(colormap(ax) == rkbwr))
     set(cb, 'YLim', [0 360], 'YTick', [0 90 180 270 360]);
 end
     

--- a/Graph/TimeSeries/graphTimeSeriesTimeFrequency.m
+++ b/Graph/TimeSeries/graphTimeSeriesTimeFrequency.m
@@ -76,14 +76,19 @@ posWithoutCb = get(ax, 'Position');
 
 h = pcolor(ax, double(xPcolor), double(yPcolor), double(var.data'));
 set(h, 'FaceColor', 'flat', 'EdgeColor', 'none');
-cb = colorbar('peer', ax);
+% 'peer' input is not recommended starting in R2014b
+if verLessThan('matlab', '8.4')
+    cb = colorbar('peer', ax);
+else
+    cb = colorbar(ax);
+end
 
 % reset position to what it was without the colorbar so that it aligns with
 % 1D datasets
 set(ax, 'Position', posWithoutCb);
 
 % Attach the context menu to colorbar
-hMenu = setTimeSerieColorbarContextMenu(var);
+hMenu = setTimeSerieColorbarContextMenu(ax, var);
 set(cb,'uicontextmenu',hMenu);
 
 % Let's redefine properties after pcolor to make sure grid lines appear

--- a/Graph/TimeSeries/graphTimeSeriesTimeFrequencyDirection.m
+++ b/Graph/TimeSeries/graphTimeSeriesTimeFrequencyDirection.m
@@ -203,10 +203,15 @@ uicontrol(mainPanel, ...
     'Position'  , posUi2(mainPanel, 50, 1, 50, 1, 0), ...
     'String'    ,'Time cursor');
     
-cb = colorbar('peer',ax);
+% 'peer' input is not recommended starting in R2014b
+if verLessThan('matlab', '8.4')
+    cb = colorbar('peer', ax);
+else
+    cb = colorbar(ax);
+end
 
 % Attach the context menu to colorbar
-hMenu = setTimeSerieColorbarContextMenu(myVar);
+hMenu = setTimeSerieColorbarContextMenu(ax, myVar);
 set(cb,'uicontextmenu',hMenu);
 
 cbLabel = imosParameters(myVar.name, 'uom');

--- a/Graph/TimeSeries/setTimeSerieColorbarContextMenu.m
+++ b/Graph/TimeSeries/setTimeSerieColorbarContextMenu.m
@@ -1,4 +1,4 @@
-function hMenu = setTimeSerieColorbarContextMenu(var)
+function hMenu = setTimeSerieColorbarContextMenu(ax, var)
 %SETTIMESERIECOLORBARCONTEXTMENU returns a context menu for colorbar 
 % specific to variables.
 %
@@ -32,7 +32,7 @@ function hMenu = setTimeSerieColorbarContextMenu(var)
 % along with this program.
 % If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
 %
-narginchk(1, 1);
+narginchk(2, 2);
 
 if ~isstruct(var), error('var must be a struct'); end
 
@@ -52,14 +52,14 @@ end
 
 switch upper(var.name(1:4))
     case {'UCUR', 'VCUR', 'WCUR', 'ECUR', 'VEL1', 'VEL2', 'VEL3', 'VEL4'} % 0 centred parameters
-        colormap(r_b);
-        cbCLimRange('', '', 'full, 0 centred', var.data); % full is chosen to attract attention on any potential outlier
+        colormap(ax, r_b);
+        cbCLimRange('', '', ax, 'full, 0 centred', var.data); % full is chosen to attract attention on any potential outlier
         
         % Define a context menu
         hMenu = uicontextmenu;
         
         % Define callbacks for context menu items that change linestyle
-        hcb11 = 'colormap(r_b)';
+        hcb11 = 'colormap(ax, r_b)';
         hcb13 = 'colormapeditor';
         
         % Define the context menu items and install their callbacks
@@ -68,19 +68,19 @@ switch upper(var.name(1:4))
         uimenu(mainItem1, 'Label', 'other',         'Callback', hcb13);
         
         mainItem2 = uimenu(hMenu, 'Label', 'Color range');
-        uimenu(mainItem2, 'Label', 'full, 0 centred (default)',       'Callback', {@cbCLimRange, 'full, 0 centred', var.data});
-        uimenu(mainItem2, 'Label', 'auto, 0 centred [0 +/-2*stdDev]', 'Callback', {@cbCLimRange, 'auto, 0 centred', var.data});
-        uimenu(mainItem2, 'Label', 'manual',                          'Callback', {@cbCLimRange, 'manual', var.data});
+        uimenu(mainItem2, 'Label', 'full, 0 centred (default)',       'Callback', {@cbCLimRange, ax, 'full, 0 centred', var.data});
+        uimenu(mainItem2, 'Label', 'auto, 0 centred [0 +/-2*stdDev]', 'Callback', {@cbCLimRange, ax, 'auto, 0 centred', var.data});
+        uimenu(mainItem2, 'Label', 'manual',                          'Callback', {@cbCLimRange, ax, 'manual', var.data});
         
     case {'CDIR', 'SSWD'} % directions
-        colormap(rkbwr);
-        cbCLimRange('', '', 'direction [0; 360]', var.data);
+        colormap(ax, rkbwr);
+        cbCLimRange('', '', ax, 'direction [0; 360]', var.data);
         
         % Define a context menu
         hMenu = uicontextmenu;
         
         % Define callbacks for context menu items that change linestyle
-        hcb11 = 'colormap(rkbwr)';
+        hcb11 = 'colormap(ax, rkbwr)';
         hcb13 = 'colormapeditor';
         
         % Define the context menu items and install their callbacks
@@ -89,19 +89,19 @@ switch upper(var.name(1:4))
         uimenu(mainItem1, 'Label', 'other',         'Callback', hcb13);
         
         mainItem2 = uimenu(hMenu, 'Label', 'Color range');
-        uimenu(mainItem2, 'Label', 'direction [0; 360] (default)',  'Callback', {@cbCLimRange, 'direction [0; 360]', var.data});
-        uimenu(mainItem2, 'Label', 'manual',                        'Callback', {@cbCLimRange, 'manual', var.data});
+        uimenu(mainItem2, 'Label', 'direction [0; 360] (default)',  'Callback', {@cbCLimRange, ax, 'direction [0; 360]', var.data});
+        uimenu(mainItem2, 'Label', 'manual',                        'Callback', {@cbCLimRange, ax, 'manual', var.data});
         
     case 'PERG' % percentages
-        colormap(parula);
-        cbCLimRange('', '', 'percent [0; 100]', var.data);
+        colormap(ax, parula);
+        cbCLimRange('', '', ax, 'percent [0; 100]', var.data);
         
         % Define a context menu
         hMenu = uicontextmenu;
         
         % Define callbacks for context menu items that change linestyle
-        hcb11 = 'colormap(parula)';
-        hcb12 = 'colormap(jet)';
+        hcb11 = 'colormap(ax, parula)';
+        hcb12 = 'colormap(ax, jet)';
         hcb13 = 'colormapeditor';
         
         % Define the context menu items and install their callbacks
@@ -111,19 +111,19 @@ switch upper(var.name(1:4))
         uimenu(mainItem1, 'Label', 'other',             'Callback', hcb13);
         
         mainItem2 = uimenu(hMenu, 'Label', 'Color range');
-        uimenu(mainItem2, 'Label', 'percent [0; 100] (default)',  'Callback', {@cbCLimRange, 'percent [0; 100]', var.data});
-        uimenu(mainItem2, 'Label', 'manual',                      'Callback', {@cbCLimRange, 'manual', var.data});
+        uimenu(mainItem2, 'Label', 'percent [0; 100] (default)',  'Callback', {@cbCLimRange, ax, 'percent [0; 100]', var.data});
+        uimenu(mainItem2, 'Label', 'manual',                      'Callback', {@cbCLimRange, ax, 'manual', var.data});
         
     case {'CSPD', 'VDEN', 'VDEV', 'VDEP', 'VDES'} % [0; oo[ paremeters
-        colormap(parula);
-        cbCLimRange('', '', 'full', var.data); % full is chosen to attract attention on any potential outlier
+        colormap(ax, parula);
+        cbCLimRange('', '', ax, 'full', var.data); % full is chosen to attract attention on any potential outlier
         
         % Define a context menu
         hMenu = uicontextmenu;
         
         % Define callbacks for context menu items that change linestyle
-        hcb11 = 'colormap(parula)';
-        hcb12 = 'colormap(jet)';
+        hcb11 = 'colormap(ax, parula)';
+        hcb12 = 'colormap(ax, jet)';
         hcb13 = 'colormapeditor';
         
         % Define the context menu items and install their callbacks
@@ -133,25 +133,25 @@ switch upper(var.name(1:4))
         uimenu(mainItem1, 'Label', 'other',             'Callback', hcb13);
         
         mainItem2 = uimenu(hMenu, 'Label', 'Color range');
-        uimenu(mainItem2, 'Label', 'full',                            'Callback', {@cbCLimRange, 'full', var.data});
-        uimenu(mainItem2, 'Label', 'full from 0 (default)',           'Callback', {@cbCLimRange, 'full from 0', var.data});
-        uimenu(mainItem2, 'Label', 'auto [mean +/-2*stdDev]',         'Callback', {@cbCLimRange, 'auto', var.data});
-        uimenu(mainItem2, 'Label', 'auto from 0 [0; mean +2*stdDev]', 'Callback', {@cbCLimRange, 'auto from 0', var.data});
-        uimenu(mainItem2, 'Label', 'manual',                          'Callback', {@cbCLimRange, 'manual', var.data});
+        uimenu(mainItem2, 'Label', 'full',                            'Callback', {@cbCLimRange, ax, 'full', var.data});
+        uimenu(mainItem2, 'Label', 'full from 0 (default)',           'Callback', {@cbCLimRange, ax, 'full from 0', var.data});
+        uimenu(mainItem2, 'Label', 'auto [mean +/-2*stdDev]',         'Callback', {@cbCLimRange, ax, 'auto', var.data});
+        uimenu(mainItem2, 'Label', 'auto from 0 [0; mean +2*stdDev]', 'Callback', {@cbCLimRange, ax, 'auto from 0', var.data});
+        uimenu(mainItem2, 'Label', 'manual',                          'Callback', {@cbCLimRange, ax, 'manual', var.data});
         
     case {'SSWV'} % [0; oo[ paremeter with special jet_w colormap
         % let's apply a colormap like jet but starting from white
         load('jet_w.mat', '-mat', 'jet_w');
-        colormap(jet_w);
-        cbCLimRange('', '', 'full', var.data); % full is chosen to attract attention on any potential outlier
+        colormap(ax, jet_w);
+        cbCLimRange('', '', ax, 'full', var.data); % full is chosen to attract attention on any potential outlier
         
         % Define a context menu
         hMenu = uicontextmenu;
         
         % Define callbacks for context menu items that change linestyle
-        hcb11 = 'load(''jet_w.mat'', ''-mat'', ''jet_w''); colormap(jet_w)';
-        hcb12 = 'colormap(parula)';
-        hcb13 = 'colormap(jet)';
+        hcb11 = 'load(''jet_w.mat'', ''-mat'', ''jet_w''); colormap(ax, jet_w)';
+        hcb12 = 'colormap(ax, parula)';
+        hcb13 = 'colormap(ax, jet)';
         hcb14 = 'colormapeditor';
         
         % Define the context menu items and install their callbacks
@@ -162,23 +162,23 @@ switch upper(var.name(1:4))
         uimenu(mainItem1, 'Label', 'other',             'Callback', hcb14);
         
         mainItem2 = uimenu(hMenu, 'Label', 'Color range');
-        uimenu(mainItem2, 'Label', 'full',                            'Callback', {@cbCLimRange, 'full', var.data});
-        uimenu(mainItem2, 'Label', 'full from 0 (default)',           'Callback', {@cbCLimRange, 'full from 0', var.data});
-        uimenu(mainItem2, 'Label', 'auto [mean +/-2*stdDev]',         'Callback', {@cbCLimRange, 'auto', var.data});
-        uimenu(mainItem2, 'Label', 'auto from 0 [0; mean +2*stdDev]', 'Callback', {@cbCLimRange, 'auto from 0', var.data});
-        uimenu(mainItem2, 'Label', 'manual',                          'Callback', {@cbCLimRange, 'manual', var.data});
+        uimenu(mainItem2, 'Label', 'full',                            'Callback', {@cbCLimRange, ax, 'full', var.data});
+        uimenu(mainItem2, 'Label', 'full from 0 (default)',           'Callback', {@cbCLimRange, ax, 'full from 0', var.data});
+        uimenu(mainItem2, 'Label', 'auto [mean +/-2*stdDev]',         'Callback', {@cbCLimRange, ax, 'auto', var.data});
+        uimenu(mainItem2, 'Label', 'auto from 0 [0; mean +2*stdDev]', 'Callback', {@cbCLimRange, ax, 'auto from 0', var.data});
+        uimenu(mainItem2, 'Label', 'manual',                          'Callback', {@cbCLimRange, ax, 'manual', var.data});
         
     otherwise
-        colormap(parula);
-        cbCLimRange('', '', 'full', var.data); % full is chosen to attract attention on any potential outlier
+        colormap(ax, parula);
+        cbCLimRange('', '', ax, 'full', var.data); % full is chosen to attract attention on any potential outlier
         
         % Define a context menu
         hMenu = uicontextmenu;
         
         % Define callbacks for context menu items that change linestyle
-        hcb11 = 'colormap(parula)';
-        hcb12 = 'colormap(jet)';
-        hcb13 = 'colormap(r_b)';
+        hcb11 = 'colormap(ax, parula)';
+        hcb12 = 'colormap(ax, jet)';
+        hcb13 = 'colormap(ax, r_b)';
         hcb14 = 'colormapeditor';
         
         % Define the context menu items and install their callbacks
@@ -189,20 +189,20 @@ switch upper(var.name(1:4))
         uimenu(mainItem1, 'Label', 'other',             'Callback', hcb14);
         
         mainItem2 = uimenu(hMenu, 'Label', 'Color range');
-        uimenu(mainItem2, 'Label', 'full (default)',                    'Callback', {@cbCLimRange, 'full', var.data});
-        uimenu(mainItem2, 'Label', 'full from 0',                       'Callback', {@cbCLimRange, 'full from 0', var.data});
-        uimenu(mainItem2, 'Label', 'full, 0 centred',                   'Callback', {@cbCLimRange, 'full, 0 centred', var.data});
-        uimenu(mainItem2, 'Label', 'auto [mean +/-2*stdDev]',           'Callback', {@cbCLimRange, 'auto', var.data});
-        uimenu(mainItem2, 'Label', 'auto from 0 [0; mean +2*stdDev]',   'Callback', {@cbCLimRange, 'auto from 0', var.data});
-        uimenu(mainItem2, 'Label', 'auto, 0 centred [0 +/-2*stdDev]',   'Callback', {@cbCLimRange, 'auto, 0 centred', var.data});
-        uimenu(mainItem2, 'Label', 'manual',                            'Callback', {@cbCLimRange, 'manual', var.data});
+        uimenu(mainItem2, 'Label', 'full (default)',                    'Callback', {@cbCLimRange, ax, 'full', var.data});
+        uimenu(mainItem2, 'Label', 'full from 0',                       'Callback', {@cbCLimRange, ax, 'full from 0', var.data});
+        uimenu(mainItem2, 'Label', 'full, 0 centred',                   'Callback', {@cbCLimRange, ax, 'full, 0 centred', var.data});
+        uimenu(mainItem2, 'Label', 'auto [mean +/-2*stdDev]',           'Callback', {@cbCLimRange, ax, 'auto', var.data});
+        uimenu(mainItem2, 'Label', 'auto from 0 [0; mean +2*stdDev]',   'Callback', {@cbCLimRange, ax, 'auto from 0', var.data});
+        uimenu(mainItem2, 'Label', 'auto, 0 centred [0 +/-2*stdDev]',   'Callback', {@cbCLimRange, ax, 'auto, 0 centred', var.data});
+        uimenu(mainItem2, 'Label', 'manual',                            'Callback', {@cbCLimRange, ax, 'manual', var.data});
         
 end
 
 end
 
 % Callback function for CLim range
-function cbCLimRange(src,eventdata, cLimMode, data)
+function cbCLimRange(src,eventdata, ax, cLimMode, data)
 
 CLim = NaN(1, 2);
 
@@ -253,7 +253,7 @@ switch cLimMode
         CLim = [-2*stdDev, 2*stdDev];
         
     case 'manual'
-        CLimCurr = get(gca, 'CLim');
+        CLimCurr = get(ax, 'CLim');
         prompt = {['{\bf', sprintf('Colorbar range :}\n\nmin value :')],...
             'max value :'};
         def                 = {num2str(CLimCurr(1)), num2str(CLimCurr(2))};
@@ -278,6 +278,6 @@ end
 
 if CLim(1) == CLim(2), CLim(2) = CLim(1) + 1; end % CLim must be increasing
 
-set(gca, 'CLim', CLim);
+set(ax, 'CLim', CLim);
 
 end


### PR DESCRIPTION
In at least R2017a onwards the use of gca in setTimeSerieColorbarContextMenu callback (cbCLimRange) results in wrong plot color range being changed. Also not specifiying an axis also resulted in wrong colormap being applied (or being applied to all plots). 

The use of 
```
if verLessThan('matlab', '8.4')
    cb = colorbar('peer', ax);
else
    cb = colorbar(ax);
end
```

is just a recommendation in R2018b manual, it doesn't yet issue a warning yet.
