### PR TITLE
Work around for Matlab >= R2018b zoom/pan etc buttons, closes #551

### DIFF
--- a/FlowManager/displayManager.m
+++ b/FlowManager/displayManager.m
@@ -248,6 +248,12 @@ function displayManager(windowTitle, sample_data, callbacks)
       try
         graphFunc = getGraphFunc(graphType, 'graph', '');
         [graphs, lines, vars] = graphFunc(panel, sample_data{setIdx}, vars, extra_sample_data);
+        if ~verLessThan('matlab', '9.5')
+            for k = 1:length(graphs)
+                disableDefaultInteractivity(graphs(k));
+                graphs(k).Toolbar.Visible = 'off';
+            end
+        end
       catch e
         errorString = getErrorString(e);
         fprintf('%s\n',   ['Error says : ' errorString]);
@@ -335,7 +341,12 @@ function displayManager(windowTitle, sample_data, callbacks)
         end
         
         [graphs, lines, vars] = graphFunc(panel, sample_data{setIdx}, vars, extra_sample_data);
-        
+        if ~verLessThan('matlab', '9.5')
+            for k = 1:length(graphs)
+                disableDefaultInteractivity(graphs(k));
+                graphs(k).Toolbar.Visible = 'off';
+            end
+        end
         if isFlagVisible
             if isempty(flagFunc)
                 warning(['Cannot display QC flags using ' graphType ...

--- a/GUI/mainWindow.m
+++ b/GUI/mainWindow.m
@@ -258,10 +258,12 @@ datacursorb = findobj(buttons, 'TooltipString', 'Data Cursor');
 
 buttons(buttons == tb)            = [];
 buttons(buttons == savefigb)      = [];
-buttons(buttons == zoominb)       = [];
-buttons(buttons == zoomoutb)      = [];
-buttons(buttons == panb)          = [];
-buttons(buttons == datacursorb)   = [];
+if verLessThan('matlab', '9.5')
+    buttons(buttons == zoominb)       = [];
+    buttons(buttons == zoomoutb)      = [];
+    buttons(buttons == panb)          = [];
+    buttons(buttons == datacursorb)   = [];
+end
 
 delete(buttons);
 
@@ -276,8 +278,40 @@ set(hZoom, 'ActionPostCallback', @zoomPostCallback);
 set(hPan,  'ActionPostCallback', @zoomPostCallback);
 
 % update zoom in and pan's tooltips to display hot keys
-set(zoominb, 'TooltipString', 'Zoom In (Ctrl+z)');
-set(panb,    'TooltipString', 'Pan (Ctrl+a)');
+if verLessThan('matlab', '9.5')
+    set(zoominb, 'TooltipString', 'Zoom In (Ctrl+z)');
+    set(panb,    'TooltipString', 'Pan (Ctrl+a)');
+else
+    zoominb = uitoggletool(tb, ...
+        'TooltipString', 'Zoom In (Ctrl+z)',...
+        'HandleVisibility', 'off', ...
+        'OnCallback', @onZoomIn, ...
+        'OffCallback', 'zoom(''off'')');
+    [img,map,alpha] = imread(fullfile(matlabroot,'toolbox','matlab','icons','tool_zoom_in.png'));
+    img = double(img)/double(intmax(class(img)));
+    img(repmat(alpha==0,[1 1 3])) = NaN;
+    zoominb.CData = img;
+
+    zoomoutb = uitoggletool(tb, ...
+        'TooltipString', 'Zoom Out',...
+        'HandleVisibility', 'off', ...
+        'OnCallback', @onZoomOut, ...
+        'OffCallback', 'zoom(''off'')');
+    [img,map,alpha] = imread(fullfile(matlabroot,'toolbox','matlab','icons','tool_zoom_out.png'));
+    img = double(img)/double(intmax(class(img)));
+    img(repmat(alpha==0,[1 1 3])) = NaN;
+    zoomoutb.CData = img;
+    
+    hPan = uitoggletool(tb, ...
+        'TooltipString',  'Pan (Ctrl+a)',...
+        'HandleVisibility', 'off', ...
+        'OnCallback', 'pan(''on'')', ...
+        'OffCallback', 'pan(''off'')');
+    [img,map,alpha] = imread(fullfile(matlabroot,'toolbox','matlab','icons','tool_hand.png'));
+    img = double(img)/double(intmax(class(img)));
+    img(repmat(alpha==0,[1 1 3])) = NaN;
+    hPan.CData = img;
+end
 
 %set uimenu
 hToolsMenu                                  = uimenu(fig,                         'label', 'Tools');
@@ -1139,4 +1173,18 @@ set(hHelpWiki, 'callBack', @openWikiPage);
         % clean up empty cells
         txt(cellfun(@isempty, txt)) = [];
     end
+
+%%
+    function onZoomIn(source, ev)
+            z = zoom;
+            z.Enable = 'on';
+            z.Direction = 'in';
+    end
+
+    function onZoomOut(source, ev)
+            z = zoom;
+            z.Enable = 'on';
+            z.Direction = 'out';
+    end
+
 end


### PR DESCRIPTION
Work around for Matlab >= R2018b where zoom/pan etc buttons no longer live on figure toolbar. Reference https://www.mathworks.com/matlabcentral/answers/419036-what-happened-to-the-figure-toolbar-in-r2018b-why-is-it-an-axes-toolbar-how-can-i-put-the-buttons

Would be nice is someone else confirms it works on there setup.