### PR TITLE
Infinity timefix, closes #536

### DIFF
--- a/Parser/infinitySDLoggerParse.m
+++ b/Parser/infinitySDLoggerParse.m
@@ -52,6 +52,16 @@ catch e
     rethrow(e);
 end
 
+%check times
+tinfo = TimeSamplingInfo(data.TIME.values);
+if tinfo.repeated_samples,
+   data.TIME.values = fixRepeatedTimesJFE(data.TIME.values);
+   tinfo = TimeSamplingInfo(data.TIME.values);
+   if ~tinfo.unique_sampling,
+      msg = sprintf('Uncorrectable time sampling detected in %s',filename);
+      warning(msg);
+   end
+end
 % copy all of the information over to the sample data struct
 sample_data = struct;
 

--- a/Util/TimeSamplingInfo.m
+++ b/Util/TimeSamplingInfo.m
@@ -1,0 +1,158 @@
+function [info] = TimeSamplingInfo(t, prec),
+    % function [info] = TimeSamplingInfo(t)
+    %
+    % Report information about a
+    % time array t, usually
+    % the returned value of datenum.
+    %
+    % Inputs:
+    %
+    % t - an array with numerical values
+    % prec - a time precision string for
+    %        time interval matching.
+    %        Default to 'milisecond'.
+    %
+    % Outputs:
+    %
+    % info - a structure with information regarding time sampling.
+    %     .sampling_steps - the sampling periods
+    %     .sampling_steps_median - the median of the sampling dt
+    %     .unique_sampling - if sampling intervals are unique
+    %     .uniform_sampling - if sampling intervals are uniform
+    %     .monotonic_sampling - if sampling are monotonic [incr/decr]
+    %     .progressive_sampling - values are generally increasing
+    %     .regressive_sampling - values are generally decreasing
+    %     .non_uniform_sampling_indexes - left-most indexes of non-uniform sampling.
+    %     .jump_magnitude - the index distance between the non-uniform  and the next uniform or non-uniform sampling
+    %     .jump_forward_indexes - the indexes where positive non-uniform sampling is found
+    %     .jump_backward_indexes - as above, but for negative sampling.
+    %
+    % Example:
+    % info = TimeSamplingInfo([1,2,3,4]);
+    % assert(info.uniform_sampling);
+    % assert(all([info.unique_sampling,info.monotonic_sampling,info.progressive_sampling]));
+    %
+    % info = TimeSamplingInfo([4,3,2,1,-1]);
+    % assert(~info.uniform_sampling);
+    % assert(all(info.sampling_steps==[-2,-1]));
+    % assert(all(info.sampling_steps_median==-1));
+    % assert(info.regressive_sampling);
+    % assert(all([info.unique_sampling,info.monotonic_sampling]));
+    %
+    % info = TimeSamplingInfo([1,2,3,5]);
+    % assert(info.non_uniform_sampling_indexes==3);
+    %
+    % info = TimeSamplingInfo([1,2,3,3]);
+    % assert(~info.uniform_sampling);
+    % assert(~all([info.unique_sampling,info.monotonic_sampling]));
+    % assert(info.non_uniform_sampling_indexes==[3]);
+    %
+    % info = TimeSamplingInfo([1,2,1,3,1,4,1,5,1]);
+    % assert(~all([info.unique_sampling,info.progressive_sampling,info.regressive_sampling,info.monotonic_sampling]));
+    % assert(isequal(info.sampling_steps_median,[]));
+    % assert(all(info.jump_forward_indexes==[1 0 1 0 1 0 1 0]));
+    % assert(all(info.jump_backward_indexes==[0 1 0 1 0 1 0 1]));
+    %
+    % author: hugo.oliveira@utas.edu.au
+    %
+
+    % Copyright (C) 2019, Australian Ocean Data Network (AODN) and Integrated
+    % Marine Observing System (IMOS).
+    %
+    % This program is free software: you can redistribute it and/or modify
+    % it under the terms of the GNU General Public License as published by
+    % the Free Software Foundation version 3 of the License.
+    %
+    % This program is distributed in the hope that it will be useful,
+    % but WITHOUT ANY WARRANTY; without even the implied warranty of
+    % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    % GNU General Public License for more details.
+    %
+    % You should have received a copy of the GNU General Public License
+    % along with this program.
+    % If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
+    %
+    if nargin < 2,
+        prec = 'milisecond';
+    end
+
+    switch prec
+        case 'day'
+            tequalizer = 1;
+        case 'hour'
+            tequalizer = 24;
+        case 'second'
+            tequalizer = 86400;
+        case 'milisecond'
+            tequalizer = 86400 * 1e3;
+        case 'microsecond'
+            tequalizer = 86400 * 1e6;
+    end
+
+    tdiff = diff(round(t * tequalizer, 0)) / tequalizer;
+
+    sampling_steps = unique(tdiff);
+    constant_vector = all(sampling_steps == 0);
+    repeated_samples = sampling_steps(1) == 0;
+
+    mfdt = median(tdiff);
+
+    tdiff_sign = sign(tdiff);
+    mfdt_sign = median(tdiff_sign);
+
+    tdiff_jumps = tdiff ~= mfdt;
+
+    info = struct();
+    info.constant_vector = constant_vector;
+    info.sampling_steps = sampling_steps;
+    info.repeated_samples = repeated_samples;
+
+    if find(mfdt == info.sampling_steps),
+        info.sampling_steps_median = mfdt;
+    else
+        info.sampling_steps_median = [];
+    end
+
+    info.unique_sampling = isunique(t);
+    info.uniform_sampling = length(info.sampling_steps) == 1;
+    info.monotonic_sampling = ~any(diff(tdiff_sign));
+    info.progressive_sampling = mfdt_sign > 0;
+    info.regressive_sampling = mfdt_sign < 0;
+
+    jind = find(tdiff_jumps);
+
+    if jind == 0
+        info.non_uniform_sampling_indexes = [];
+    else
+        info.non_uniform_sampling_indexes = jind;
+    end
+
+    jval = tdiff(tdiff_jumps);
+
+    no_jumps = isempty(jval);
+
+    if no_jumps,
+        info.jump_magnitude = [];
+        info.jump_forward_indexes = [];
+        info.jump_backward_indexes = [];
+    else
+        info.jump_magnitude = jval;
+
+        if length(jval) > 1,
+            info.jump_forward_indexes = jval > 0;
+            info.jump_backward_indexes = jval < 0;
+            else,
+
+            if jval > 0
+                info.jump_forward_indexes = find(tdiff == jval);
+                info.jump_backward_indexes = [];
+            else
+                info.jump_forward_indexes = [];
+                info.jump_backward_indexes = find(tdiff == jval);
+            end
+
+        end
+
+    end
+
+end

--- a/Util/TimeSamplingInfo.m
+++ b/Util/TimeSamplingInfo.m
@@ -28,24 +28,10 @@ function [info] = TimeSamplingInfo(t, prec),
     %     .jump_backward_indexes - as above, but for negative sampling.
     %
     % Example:
+    %
     % info = TimeSamplingInfo([1,2,3,4]);
     % assert(info.uniform_sampling);
     % assert(all([info.unique_sampling,info.monotonic_sampling,info.progressive_sampling]));
-    %
-    % info = TimeSamplingInfo([4,3,2,1,-1]);
-    % assert(~info.uniform_sampling);
-    % assert(all(info.sampling_steps==[-2,-1]));
-    % assert(all(info.sampling_steps_median==-1));
-    % assert(info.regressive_sampling);
-    % assert(all([info.unique_sampling,info.monotonic_sampling]));
-    %
-    % info = TimeSamplingInfo([1,2,3,5]);
-    % assert(info.non_uniform_sampling_indexes==3);
-    %
-    % info = TimeSamplingInfo([1,2,3,3]);
-    % assert(~info.uniform_sampling);
-    % assert(~all([info.unique_sampling,info.monotonic_sampling]));
-    % assert(info.non_uniform_sampling_indexes==[3]);
     %
     % info = TimeSamplingInfo([1,2,1,3,1,4,1,5,1]);
     % assert(~all([info.unique_sampling,info.progressive_sampling,info.regressive_sampling,info.monotonic_sampling]));

--- a/Util/find_repeats.m
+++ b/Util/find_repeats.m
@@ -1,0 +1,114 @@
+function [ritem, repeats, rstart, rend] = find_repeats(arr),
+    % function repeats,nr = find_repeats(arr)
+    %
+    % Find the groups of repeated numbers,
+    % the number of repeats, and the index interval
+    % they occur.
+    %
+    % Inputs:
+    %
+    % arr - a vector numeric array.
+    %
+    % Outputs:
+    %
+    % ritem - an array of repeated items.
+    % repeats - an array with the respective number of repeats.
+    % rstart - the start index of the repeat interval.
+    % rend - the end index of the repeat interval.
+    %
+    % Example:
+    % % basic
+    % [ritem,repeats,rstart,rend] = find_repeats([1,1,1]);
+    % assert(ritem == 1);
+    % assert(repeats == 3);
+    % assert(rstart == 1);
+    % assert(rend == 3);
+    %
+    % %mix & match
+    % x = [.1,.1,.1,.1,.2,.3,.3,.3]
+    % [ritem,repeats,rstart,rend] = find_repeats(x);
+    % assert(ritem == [0.1,0.3]);
+    % assert(repeats == [4,3]);
+    % assert(rstart == [1,6]);
+    % assert(rend == [4,8]);
+    %
+    % %repeat only at mid
+    % x = [.1,.2,.2,.3]
+    % [ritem,repeats,rstart,rend] = find_repeats(x);
+    % assert(ritem == 0.2);
+    % assert(repeats == 2);
+    % assert(rstart == 2);
+    % assert(rend == 3);
+    %
+    % author: hugo.oliveira@utas.edu.au
+    %
+
+    % Copyright (C) 2019, Australian Ocean Data Network (AODN) and Integrated
+    % Marine Observing System (IMOS).
+    %
+    % This program is free software: you can redistribute it and/or modify
+    % it under the terms of the GNU General Public License as published by
+    % the Free Software Foundation version 3 of the License.
+    %
+    % This program is distributed in the hope that it will be useful,
+    % but WITHOUT ANY WARRANTY; without even the implied warranty of
+    % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    % GNU General Public License for more details.
+    %
+    % You should have received a copy of the GNU General Public License
+    % along with this program.
+    % If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
+    %
+
+    if ~isvector(arr),
+        error('argument not a vector')
+    end
+
+    if ~issorted(arr),
+        error('vector is not sorted')
+    end
+
+    alen = length(arr);
+    [uniq, uniq_inds, non_uniq_inds] = unique(arr);
+    ni = sum(diff(non_uniq_inds))+1;
+
+    repeats = zeros(ni, 0);
+    ritem = zeros(ni, 0);
+    rstart = zeros(ni, 0);
+    rend = zeros(ni, 0);
+
+    if all(size(uniq) == size(arr)),
+        return
+    end
+
+    c = 0;
+    for k = 2:length(uniq_inds),
+        istart = uniq_inds(k - 1);
+        iend = uniq_inds(k) - 1;
+        ilen = iend - istart + 1;
+
+        if ilen == 1,
+            continue
+        end
+
+        c = c + 1;
+        repeats(c) = ilen;
+        ritem(c) = arr(istart);
+        rstart(c) = istart;
+        rend(c) = iend;
+    end
+
+    repeat_at_end = uniq_inds(end) < alen;
+
+    if repeat_at_end,
+        istart = uniq_inds(end);
+        iend = alen;
+        ilen = iend - istart + 1;
+        c = c + 1;
+        repeats(c) = ilen;
+        ritem(c) = arr(istart);
+        rstart(c) = istart;
+        rend(c) = iend;
+    end
+
+end

--- a/Util/fixRepeatedTimesJFE.m
+++ b/Util/fixRepeatedTimesJFE.m
@@ -1,0 +1,136 @@
+function [newtime] = fixRepeatedTimesJFE(time),
+    % function newtime = fixRepeatedTimesJFE(time),
+    %
+    % Add the missing miliseconds to the repeated
+    % date numbers in the time array based on their
+    % ordering and the number of repeated entries.
+    %
+    % Problem:
+    % The date number entries when reading JFE inifinity
+    % instrument dat files are precision clipped.
+    %
+    % Scope:
+    % Required fix when the insturment is set for
+    % sub-second sampling and reporting.
+    %
+    % Inputs:
+    %
+    % time - the entire time vector read from the instrument file
+    %        in days
+    %
+    % Outputs:
+    %
+    % newtime - the new time values with miliseconds accounted for.
+    %
+    % Example:
+    % sbase = 1/86400;
+    % fmt = 'MM:SS.FFF';
+    % vstart = repmat(sbase,1,3);
+    % vmid = repmat(2*sbase,1,10);
+    % vjump = repmat(15*60*sbase,1,10);
+    % vend = repmat(16*60*sbase,1,5);
+    % time = horzcat(vstart,vmid,vjump,vend);
+    % [newtime] = fixRepeatedTimesJFE(time);
+    % assert(strcmpi('00:01.700',datestr(newtime(1),fmt)));
+    % assert(strcmpi('00:01.900',datestr(newtime(3),fmt)));
+    % assert(strcmpi('00:02.000',datestr(newtime(4),fmt)));
+    % assert(strcmpi('00:02.900',datestr(newtime(13),fmt)));
+    % assert(strcmpi('15:00.000',datestr(newtime(14),fmt)));
+    % assert(strcmpi('15:00.100',datestr(newtime(15),fmt)));
+    % assert(strcmpi('15:00.900',datestr(newtime(23),fmt)));
+    % assert(strcmpi('16:00.000',datestr(newtime(24),fmt)));
+    % assert(strcmpi('16:00.400',datestr(newtime(end),fmt)));
+    %
+    % author: hugo.oliveira@utas.edu.au
+    %
+
+    % Copyright (C) 2019, Australian Ocean Data Network (AODN) and Integrated
+    % Marine Observing System (IMOS).
+    %
+    % This program is free software: you can redistribute it and/or modify
+    % it under the terms of the GNU General Public License as published by
+    % the Free Software Foundation version 3 of the License.
+    %
+    % This program is distributed in the hope that it will be useful,
+    % but WITHOUT ANY WARRANTY; without even the implied warranty of
+    % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    % GNU General Public License for more details.
+    %
+    % You should have received a copy of the GNU General Public License
+    % along with this program.
+    % If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
+    %
+
+    tlen = length(time);
+    tsize = size(time);
+    not_a_vector = tsize(1) ~= 1 && tsize(2) ~= 1;
+
+    if not_a_vector,
+        error('argument not a vector')
+    end
+
+    if ~issorted(time),
+        error('time is not sorted')
+    end
+
+    tinfo = TimeSamplingInfo(time);
+
+    if tinfo.constant_vector,
+        error('time is a constant vector')
+    end
+
+    if tinfo.unique_sampling,
+        newtime = time;
+        return
+    end
+
+    if ~tinfo.repeated_samples,
+        newtime = time;
+        return
+    end
+
+    %repeats + burst sampling + burst interval
+    % 0      + dt             +  dt*n
+    if tinfo.sampling_steps > 3
+        error('Vector contains more than 3 sampling frequencies')
+    end
+
+    newtime = zeros(tsize);
+
+    freq = tinfo.sampling_steps(2); % sampling_steps is sorted
+
+    [ritem, nrepeats, rstart, rend] = find_repeats(time);
+
+    nur = unique(nrepeats);
+    % use maximum number of repeats for interval correction
+    maxrepeat = max(nur);
+
+    % allow only the start and end of a series to have different
+    % len of repeats.
+    wildly_repeated = length(nur) > 3;
+
+    if wildly_repeated,
+        msg = sprintf('Number of different repeats is too big %d', nur);
+        error(msg);
+    end
+
+    partial_time = @(freq, nr) freq * (0:nr - 1) / nr;
+
+    %boundary conditions
+    ztime = partial_time(freq, maxrepeat);
+    stime = ztime(end - nrepeats(1) + 1:end);
+    etime = ztime(1:nrepeats(end));
+    newtime(rstart(1):rend(1)) = stime;
+    newtime(rstart(end):rend(end)) = etime;
+
+    for k = 2:length(rstart) - 1
+        is = rstart(k);
+        ie = rend(k);
+        ilen = nrepeats(k);
+        ztime = partial_time(freq, ilen);
+        newtime(is:ie) = ztime;
+    end
+
+    newtime = newtime + time;
+
+end

--- a/Util/isunique.m
+++ b/Util/isunique.m
@@ -1,0 +1,47 @@
+function [bool, ulen, uniq_inds, non_uniq_inds] = isunique(x),
+    % function [bool, ulen, uindex, nonuindex] = isUnique(x)
+    %
+    % A wrapper that checks if an array is unique. Extra output
+    % arguments are commonly used for uniqueness processing.
+    %
+    % Inputs:
+    %
+    % x - an array
+    %
+    % Outputs:
+    %
+    % bool - a boolean for uniqueness
+    % ulen - the length of unique array
+    % uniq_inds - the set of indexes that turn x into
+    %             a unique array.
+    % non_uniq_inds - a non-unique set of indexes that
+    %                 creates a non-unique x.
+    %
+    % Example:
+    % assert(isunique([1,2,3]))
+    %
+    % author: hugo.oliveira@utas.edu.au
+    %
+
+    %
+    % Copyright (C) 2019, Australian Ocean Data Network (AODN) and Integrated
+    % Marine Observing System (IMOS).
+    %
+    % This program is free software: you can redistribute it and/or modify
+    % it under the terms of the GNU General Public License as published by
+    % the Free Software Foundation version 3 of the License.
+    %
+    % This program is distributed in the hope that it will be useful,
+    % but WITHOUT ANY WARRANTY; without even the implied warranty of
+    % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    % GNU General Public License for more details.
+
+    % You should have received a copy of the GNU General Public License
+    % along with this program.
+    % If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
+    %
+
+    [uarray, uniq_inds, non_uniq_inds] = unique(x);
+    ulen = length(uarray);
+    bool = length(x) == ulen;
+end

--- a/test/Util/testTimeSamplingInfo.m
+++ b/test/Util/testTimeSamplingInfo.m
@@ -1,0 +1,42 @@
+classdef testTimeSamplingInfo < matlab.unittest.TestCase
+
+    methods (Test)
+
+        function test_simple_monotonic(testCase),
+            info = TimeSamplingInfo([1, 2, 3, 4]);
+            assert(info.uniform_sampling);
+            assert(all([info.unique_sampling, info.monotonic_sampling, info.progressive_sampling]));
+        end
+
+        function test_decreasing_with_jump_at_end(testCase),
+            info = TimeSamplingInfo([4, 3, 2, 1, -1]);
+            assert(~info.uniform_sampling);
+            assert(all(info.sampling_steps == [-2, -1]));
+            assert(all(info.sampling_steps_median == -1));
+            assert(info.regressive_sampling);
+            assert(all([info.unique_sampling, info.monotonic_sampling]));
+        end
+
+        function test_increasing_with_jump_at_end(testCase),
+            info = TimeSamplingInfo([1, 2, 3, 5]);
+            assert(info.non_uniform_sampling_indexes == 3);
+        end
+
+        function test_increasing_with_repeat(testCase),
+            info = TimeSamplingInfo([1, 2, 3, 3]);
+            assert(~info.uniform_sampling);
+            assert(~all([info.unique_sampling, info.monotonic_sampling]));
+            assert(info.non_uniform_sampling_indexes == [3]);
+        end
+
+        function test_jump_forward_backward(testCase),
+            info = TimeSamplingInfo([1, 2, 1, 3, 1, 4, 1, 5, 1]);
+            assert(~all([info.unique_sampling, info.progressive_sampling, info.regressive_sampling, info.monotonic_sampling]));
+            assert(isequal(info.sampling_steps_median, []));
+            assert(all(info.jump_forward_indexes == [1 0 1 0 1 0 1 0]));
+            assert(all(info.jump_backward_indexes == [0 1 0 1 0 1 0 1]));
+        end
+
+    end
+
+end

--- a/test/testRepeatedTimesJFE.m
+++ b/test/testRepeatedTimesJFE.m
@@ -1,0 +1,55 @@
+classdef testRepeatedTimesJFE < matlab.unittest.TestCase
+    %
+    % Test JFE infinity with high-frequency sampling.
+    % The instrument software do not output microseconds
+    % resulting in repeated time entries that need to be
+    % corrected.
+    %
+    % author: hugo.oliveira@utas.edu.au
+    %
+
+    % Copyright (C) 2019, Australian Ocean Data Network (AODN) and Integrated
+    % Marine Observing System (IMOS).
+    %
+    % This program is free software: you can redistribute it and/or modify
+    % it under the terms of the GNU General Public License as published by
+    % the Free Software Foundation version 3 of the License.
+    %
+    % This program is distributed in the hope that it will be useful,
+    % but WITHOUT ANY WARRANTY; without even the implied warranty of
+    % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    % GNU General Public License for more details.
+    %
+    % You should have received a copy of the GNU General Public License
+    % along with this program.
+    % If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
+    %
+    properties (TestParameter)
+        mode = {'timeSeries'}; %, 'profile'};
+        jfe_param = load_param();
+    end
+
+    methods (Test)
+
+        function testNonRepeatedTimes(testCase, jfe_param,mode),
+            data = infinitySDLoggerParse({jfe_param}, mode);
+            istime = @(x) strcmpi(x.name, 'TIME');
+            timeind = find(cellfun(istime, data.dimensions));
+            time = data.dimensions{timeind};
+            tinfo = TimeSamplingInfo(time.data);
+            valid_sampling = all([tinfo.unique_sampling, tinfo.monotonic_sampling, tinfo.progressive_sampling]);
+            valid_interval = data.meta.instrument_sample_interval/min(tinfo.sampling_steps) > 0;
+            assert(valid_sampling);
+            assert(valid_interval);
+        end
+
+    end
+
+end
+
+function [param] = load_param(),
+    root_folder = FolderAbove(mfilename('fullpath'), 1);
+    folder = fullfile(root_folder, 'data/testfiles/JFE/v000');
+    files = FilesInFolder(folder);
+    param = files2namestruct(files);
+end

--- a/test/testRepeatedTimesJFE.m
+++ b/test/testRepeatedTimesJFE.m
@@ -31,10 +31,10 @@ classdef testRepeatedTimesJFE < matlab.unittest.TestCase
 
     methods (Test)
 
-        function testNonRepeatedTimes(testCase, jfe_param,mode),
+        function testNonRepeatedTimes(~, jfe_param,mode)
             data = infinitySDLoggerParse({jfe_param}, mode);
             istime = @(x) strcmpi(x.name, 'TIME');
-            timeind = find(cellfun(istime, data.dimensions));
+            timeind = cellfun(istime, data.dimensions);
             time = data.dimensions{timeind};
             tinfo = TimeSamplingInfo(time.data);
             valid_sampling = all([tinfo.unique_sampling, tinfo.monotonic_sampling, tinfo.progressive_sampling]);
@@ -47,7 +47,7 @@ classdef testRepeatedTimesJFE < matlab.unittest.TestCase
 
 end
 
-function [param] = load_param(),
+function [param] = load_param()
     root_folder = FolderAbove(mfilename('fullpath'), 1);
     folder = fullfile(root_folder, 'data/testfiles/JFE/v000');
     files = FilesInFolder(folder);


### PR DESCRIPTION
This fixes the problem with InfinitySD not outputing the miliseconds of burst measurements.

- [x] Support correction when repetition occurs
- [x] correction takes into account the number of repeats
- [x] correction support time vectors starting and ending in the middle of a burst
- [x] Tests available and pass the cases.


