### PR TITLE
quickfix: missing renames of timeSamplingInfo function

### DIFF
--- a/Parser/infinitySDLoggerParse.m
+++ b/Parser/infinitySDLoggerParse.m
@@ -53,10 +53,10 @@ catch e
 end
 
 %check times
-tinfo = TimeSamplingInfo(data.TIME.values);
+tinfo = timeSamplingInfo(data.TIME.values);
 if tinfo.repeated_samples,
    data.TIME.values = fixRepeatedTimesJFE(data.TIME.values);
-   tinfo = TimeSamplingInfo(data.TIME.values);
+   tinfo = timeSamplingInfo(data.TIME.values);
    if ~tinfo.unique_sampling,
       msg = sprintf('Uncorrectable time sampling detected in %s',filename);
       warning(msg);

--- a/test/Util/testtimeSamplingInfo.m
+++ b/test/Util/testtimeSamplingInfo.m
@@ -1,15 +1,15 @@
-classdef testTimeSamplingInfo < matlab.unittest.TestCase
+classdef testtimeSamplingInfo < matlab.unittest.TestCase
 
     methods (Test)
 
         function test_simple_monotonic(testCase),
-            info = TimeSamplingInfo([1, 2, 3, 4]);
+            info = timeSamplingInfo([1, 2, 3, 4]);
             assert(info.uniform_sampling);
             assert(all([info.unique_sampling, info.monotonic_sampling, info.progressive_sampling]));
         end
 
         function test_decreasing_with_jump_at_end(testCase),
-            info = TimeSamplingInfo([4, 3, 2, 1, -1]);
+            info = timeSamplingInfo([4, 3, 2, 1, -1]);
             assert(~info.uniform_sampling);
             assert(all(info.sampling_steps == [-2, -1]));
             assert(all(info.sampling_steps_median == -1));
@@ -18,19 +18,19 @@ classdef testTimeSamplingInfo < matlab.unittest.TestCase
         end
 
         function test_increasing_with_jump_at_end(testCase),
-            info = TimeSamplingInfo([1, 2, 3, 5]);
+            info = timeSamplingInfo([1, 2, 3, 5]);
             assert(info.non_uniform_sampling_indexes == 3);
         end
 
         function test_increasing_with_repeat(testCase),
-            info = TimeSamplingInfo([1, 2, 3, 3]);
+            info = timeSamplingInfo([1, 2, 3, 3]);
             assert(~info.uniform_sampling);
             assert(~all([info.unique_sampling, info.monotonic_sampling]));
             assert(info.non_uniform_sampling_indexes == [3]);
         end
 
         function test_jump_forward_backward(testCase),
-            info = TimeSamplingInfo([1, 2, 1, 3, 1, 4, 1, 5, 1]);
+            info = timeSamplingInfo([1, 2, 1, 3, 1, 4, 1, 5, 1]);
             assert(~all([info.unique_sampling, info.progressive_sampling, info.regressive_sampling, info.monotonic_sampling]));
             assert(isequal(info.sampling_steps_median, []));
             assert(all(info.jump_forward_indexes == [1 0 1 0 1 0 1 0]));

--- a/test/testRepeatedTimesJFE.m
+++ b/test/testRepeatedTimesJFE.m
@@ -36,7 +36,7 @@ classdef testRepeatedTimesJFE < matlab.unittest.TestCase
             istime = @(x) strcmpi(x.name, 'TIME');
             timeind = cellfun(istime, data.dimensions);
             time = data.dimensions{timeind};
-            tinfo = TimeSamplingInfo(time.data);
+            tinfo = timeSamplingInfo(time.data);
             valid_sampling = all([tinfo.unique_sampling, tinfo.monotonic_sampling, tinfo.progressive_sampling]);
             valid_interval = data.meta.instrument_sample_interval/min(tinfo.sampling_steps) > 0;
             assert(valid_sampling);
@@ -48,7 +48,7 @@ classdef testRepeatedTimesJFE < matlab.unittest.TestCase
 end
 
 function [param] = load_param()
-    root_folder = FolderAbove(mfilename('fullpath'), 1);
+    root_folder = FolderAbove(mfilename('fullpath'), 2);
     folder = fullfile(root_folder, 'data/testfiles/JFE/v000');
     files = FilesInFolder(folder);
     param = files2namestruct(files);


### PR DESCRIPTION
I clearly missed running the tests before submitting
> #598.

This complete the renames of the function in the parser, test functions and
also corrected the path of the test file.