### PR TITLE
Cellutils fixes

### DIFF
--- a/Util/CellUtils/inCellPartialMatch.m
+++ b/Util/CellUtils/inCellPartialMatch.m
@@ -7,7 +7,9 @@ function [is_complete, indexes] = inCellPartialMatch(xcell, ycell, allmatches)
     % is found within the substring of xcell{m}
     % the m index is stored.
     % Hence, matched indexes indicates a full or partial match
-    % of all the substrings in ycell{n} against a xcell{m}.
+    % ignoring whitespace of all the substrings in ycell{n} against a xcell{m}
+    %
+    % For simple partial string matching, use the contains function
     %
     % See examples for usage.
     %
@@ -33,20 +35,20 @@ function [is_complete, indexes] = inCellPartialMatch(xcell, ycell, allmatches)
     %
     %
     % Example:
-    % astr = sprintf('a\tb\tc')
-    % [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a b'})
+    % astr = sprintf('a\tb\tc');
+    % [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a b'});
     % assert(is_complete)
     % assert(isequal(indexes,[1]))
     % % Partial matching
-    % is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a c'})
+    % [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a c'});
     % assert(is_complete)
     % assert(isequal(indexes,[1]))
     % % Partial matching reduced
-    % [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a c','c'})
+    % [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a c','c'});
     % assert(is_complete)
-    % assert(isequal(indexes,[1,1]))
+    % assert(isequal(indexes,[1;1]))
     % % Partial matching complete
-    % [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a c','c'},true)
+    % [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a c','c'},true);
     % assert(is_complete)
     % assert(iscell(indexes))
     % assert(isequal(indexes{1},{1}))
@@ -78,12 +80,12 @@ function [is_complete, indexes] = inCellPartialMatch(xcell, ycell, allmatches)
         allmatches = false;
     end
 
-    cindexes = {};
 
     if ~iscell(ycell)
         ycell = {ycell};
     end
-
+    
+    cindexes = cell(1,length(ycell));
     for k = 1:length(ycell)
         cindexes{k} = {};
 
@@ -120,7 +122,7 @@ function [is_complete, indexes] = inCellPartialMatch(xcell, ycell, allmatches)
         if allmatches
             indexes = cindexes;
         else
-            if incomplete && isempty(empty_entries)
+            if incomplete && length(empty_entries) == 1 && empty_entries(1) == 1
                 indexes = [];
                 return
             end

--- a/Util/CellUtils/inCellPartialMatch.m
+++ b/Util/CellUtils/inCellPartialMatch.m
@@ -1,139 +1,145 @@
 function [is_complete, indexes] = inCellPartialMatch(xcell, ycell, allmatches)
-    % function [indexes,is_complete] = inCellPartialMatch(xcell, ycell, allmatches)
-    %
-    % Compare all substrings of ycell against substrings in xcell
-    % ignoring whitespaces.
-    % If all the content of a ycell{n} substring
-    % is found within the substring of xcell{m}
-    % the m index is stored.
-    % Hence, matched indexes indicates a full or partial match
-    % ignoring whitespace of all the substrings in ycell{n} against a xcell{m}
-    %
-    % For simple partial string matching, use the contains function
-    %
-    % See examples for usage.
-    %
-    % Inputs:
-    %
-    % xcell - a cell with items as strings.
-    %         Items may have spaces,tabs,etc. that will be ignored.
-    % ycell - a string or a cell with items as strings.
-    %         As above, items may have any whitespace marker.
-    % allmatches - a boolean to return all matched indexes in a cell,
-    %              otherwise only the first indexes are returned
-    %              in an array.
-    %              Default: false.
-    %
-    % Output:
-    %
-    % is_complete - a boolean to indicate that all ycell indexes
-    %               were matched.
-    % indexes - If `allmatches` is false, return an array of indexes
-    %           only for the the first matches in xcell.
-    %           If `allmatches` is true, return an cell of indexes
-    %           with all matches in xcell.
-    %
-    %
-    % Example:
-    % astr = sprintf('a\tb\tc');
-    % [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a b'});
-    % assert(is_complete)
-    % assert(isequal(indexes,[1]))
-    % % Partial matching
-    % [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a c'});
-    % assert(is_complete)
-    % assert(isequal(indexes,[1]))
-    % % Partial matching reduced
-    % [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a c','c'});
-    % assert(is_complete)
-    % assert(isequal(indexes,[1;1]))
-    % % Partial matching complete
-    % [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a c','c'},true);
-    % assert(is_complete)
-    % assert(iscell(indexes))
-    % assert(isequal(indexes{1},{1}))
-    % assert(isequal(indexes{2},{1,3}))
-    %
-    % author: hugo.oliveira@utas.edu.au
-    %
+% function [indexes,is_complete] = inCellPartialMatch(xcell, ycell, allmatches)
+%
+% Compare all substrings of ycell against substrings in xcell
+% ignoring whitespaces.
+% If all the content of a ycell{n} substring
+% is found within the substring of xcell{m}
+% the m index is stored.
+% Hence, matched indexes indicates a full or partial match
+% ignoring whitespace of all the substrings in ycell{n} against a xcell{m}
+%
+% For simple partial string matching, use the contains function
+%
+% See examples for usage.
+%
+% Inputs:
+%
+% xcell - a cell with items as strings.
+%         Items may have spaces,tabs,etc. that will be ignored.
+% ycell - a string or a cell with items as strings.
+%         As above, items may have any whitespace marker.
+% allmatches - a boolean to return all matched indexes in a cell,
+%              otherwise only the first indexes are returned
+%              in an array.
+%              Default: false.
+%
+% Output:
+%
+% is_complete - a boolean to indicate that all ycell indexes
+%               were matched.
+% indexes - If `allmatches` is false, return an array of indexes
+%           only for the the first matches in xcell.
+%           If `allmatches` is true, return an cell of indexes
+%           with all matches in xcell.
+%
+%
+% Example:
+% astr = sprintf('a\tb\tc');
+% [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a b'});
+% assert(is_complete)
+% assert(isequal(indexes,[1]))
+% % Partial matching
+% [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a c'});
+% assert(is_complete)
+% assert(isequal(indexes,[1]))
+% % Partial matching reduced
+% [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a c','c'});
+% assert(is_complete)
+% assert(isequal(indexes,[1;1]))
+% % Partial matching complete
+% [is_complete,indexes] = inCellPartialMatch({astr,'b','c'},{'a c','c'},true);
+% assert(is_complete)
+% assert(iscell(indexes))
+% assert(isequal(indexes{1},{1}))
+% assert(isequal(indexes{2},{1,3}))
+%
+% author: hugo.oliveira@utas.edu.au
+%
 
-    % Copyright (C) 2019, Australian Ocean Data Network (AODN) and Integrated
-    % Marine Observing System (IMOS).
-    %
-    % This program is free software: you can redistribute it and/or modify
-    % it under the terms of the GNU General Public License as published by
-    % the Free Software Foundation version 3 of the License.
-    %
-    % This program is distributed in the hope that it will be useful,
-    % but WITHOUT ANY WARRANTY; without even the implied warranty of
-    % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    % GNU General Public License for more details.
-    %
-    % You should have received a copy of the GNU General Public License
-    % along with this program.
-    % If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
-    %
+% Copyright (C) 2019, Australian Ocean Data Network (AODN) and Integrated
+% Marine Observing System (IMOS).
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation version 3 of the License.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.
+% If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
+%
 
-    narginchk(2, 3)
+narginchk(2, 3)
 
-    if nargin < 3
-        allmatches = false;
+if nargin < 3
+    allmatches = false;
+end
+
+if ~iscell(ycell)
+    ycell = {ycell};
+end
+
+cindexes = cell(1, length(ycell));
+
+for k = 1:length(ycell)
+    cindexes{k} = {};
+
+    if ~ischar(ycell{k})
+        error('The second argument index `ycell{%d}` is not a string', k);
     end
 
+    ysplit = strsplit(ycell{k});
 
-    if ~iscell(ycell)
-        ycell = {ycell};
-    end
-    
-    cindexes = cell(1,length(ycell));
-    for k = 1:length(ycell)
-        cindexes{k} = {};
+    c = 0;
 
-        if ~ischar(ycell{k})
-            error('The second argument index `ycell{%d}` is not a string', k);
+    for kk = 1:length(xcell)
+
+        if ~ischar(xcell{kk})
+            error('The first argument index `xcell{%d}` is not a string', k);
         end
 
-        ysplit = strsplit(ycell{k});
+        xsplit = strsplit(xcell{kk});
+        [~, is_complete] = whereincell(xsplit, ysplit);
 
-        c = 0;
-
-        for kk = 1:length(xcell)
-
-            if ~ischar(xcell{kk})
-                error('The first argument index `xcell{%d}` is not a string',k);
-            end
-
-            xsplit = strsplit(xcell{kk});
-            [~, is_complete] = whereincell(xsplit, ysplit);
-
-            if is_complete
-                c = c + 1;
-                cindexes{k}{c} = kk;
-            end
-
+        if is_complete
+            c = c + 1;
+            cindexes{k}{c} = kk;
         end
 
     end
 
-    [incomplete, empty_entries] = inCell(cindexes, cell(0, 0));
-    is_complete = ~incomplete;
+end
 
-    if nargout>1
-        if allmatches
-            indexes = cindexes;
-        else
-            if incomplete && length(empty_entries) == 1 && empty_entries(1) == 1
-                indexes = [];
-                return
-            end
-            vind = popFromCell(num2cell(1:length(cindexes)), num2cell(empty_entries));
-            asize = length(vind);
-            indexes = zeros(asize, 1);
+[incomplete, empty_entries] = inCell(cindexes, cell(0, 0));
+is_complete = ~incomplete;
 
-            for ni = 1:length(vind)
-                ind = vind{ni};
-                indexes(ni) = cindexes{ind}{1};
-            end
+if nargout > 1
+
+    if allmatches
+        indexes = cindexes;
+    else
+
+        if incomplete && length(empty_entries) == 1 && empty_entries(1) == 1
+            indexes = [];
+            return
         end
+
+        vind = popFromCell(num2cell(1:length(cindexes)), num2cell(empty_entries));
+        asize = length(vind);
+        indexes = zeros(asize, 1);
+
+        for ni = 1:length(vind)
+            ind = vind{ni};
+            indexes(ni) = cindexes{ind}{1};
+        end
+
     end
+
+end
+
 end

--- a/Util/CellUtils/popFromCell.m
+++ b/Util/CellUtils/popFromCell.m
@@ -44,7 +44,7 @@ function [newcell, rm_indexes] = popFromCell(xcell, match)
     % If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
     %
 
-    flen = numel(csize);
+    flen = numel(xcell);
     newcell = cell(1);
 
     not_cell_or_str = not(iscell(match) || ischar(match));

--- a/Util/CellUtils/popFromCell.m
+++ b/Util/CellUtils/popFromCell.m
@@ -15,13 +15,13 @@ function [newcell, rm_indexes] = popFromCell(xcell, match)
 % rm_indexes - the indexes where match was found
 %
 % Examples:
-% [newcell] = popFromCell({1,2,3},{2,3})
+% [newcell] = popFromCell({1,2,3},{2,3});
 % assert(isequal(newcell,{1}))
 % % 2nd arg string
-% [newcell] = popFromCell({'a','b'},'b')
+% [newcell] = popFromCell({'a','b'},'b');
 % assert(isequal(newcell,{'a'}))
 % % raise error for empty 2nd arg
-% [newcell] = popFromCell({'a'},'')
+% [newcell] = popFromCell({'a'},'');
 % %error, not found in cell.
 %
 % author: hugo.oliveira@utas.edu.au

--- a/Util/CellUtils/popFromCell.m
+++ b/Util/CellUtils/popFromCell.m
@@ -1,99 +1,101 @@
 function [newcell, rm_indexes] = popFromCell(xcell, match)
-    %function [newcell,rm_indexes] = popFromCell(xcell, match)
-    %
-    % generate a new cell with an item removed
-    %
-    % Inputs:
-    %
-    % xcell - the cell
-    % match - a cell containing the items to remove
-    %         or a string.
-    %
-    % Outputs:
-    %
-    % newcell - the cell with `match` removed
-    % rm_indexes - the indexes where match was found
-    %
-    % Examples:
-    % [newcell] = popFromCell({1,2,3},{2,3})
-    % assert(isequal(newcell,{1}))
-    % % 2nd arg string
-    % [newcell] = popFromCell({'a','b'},'b')
-    % assert(isequal(newcell,{'a'}))
-    % % raise error for empty 2nd arg
-    % [newcell] = popFromCell({'a'},'')
-    % %error, not found in cell.
-    %
-    % author: hugo.oliveira@utas.edu.au
-    %
+%function [newcell,rm_indexes] = popFromCell(xcell, match)
+%
+% generate a new cell with an item removed
+%
+% Inputs:
+%
+% xcell - the cell
+% match - a cell containing the items to remove
+%         or a string.
+%
+% Outputs:
+%
+% newcell - the cell with `match` removed
+% rm_indexes - the indexes where match was found
+%
+% Examples:
+% [newcell] = popFromCell({1,2,3},{2,3})
+% assert(isequal(newcell,{1}))
+% % 2nd arg string
+% [newcell] = popFromCell({'a','b'},'b')
+% assert(isequal(newcell,{'a'}))
+% % raise error for empty 2nd arg
+% [newcell] = popFromCell({'a'},'')
+% %error, not found in cell.
+%
+% author: hugo.oliveira@utas.edu.au
+%
 
-    % Copyright (C) 2019, Australian Ocean Data Network (AODN) and Integrated
-    % Marine Observing System (IMOS).
-    %
-    % This program is free software: you can redistribute it and/or modify
-    % it under the terms of the GNU General Public License as published by
-    % the Free Software Foundation version 3 of the License.
-    %
-    % This program is distributed in the hope that it will be useful,
-    % but WITHOUT ANY WARRANTY; without even the implied warranty of
-    % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    % GNU General Public License for more details.
-    %
-    % You should have received a copy of the GNU General Public License
-    % along with this program.
-    % If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
-    %
+% Copyright (C) 2019, Australian Ocean Data Network (AODN) and Integrated
+% Marine Observing System (IMOS).
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation version 3 of the License.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.
+% If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
+%
 
-    flen = numel(xcell);
-    newcell = cell(1);
+flen = numel(xcell);
+newcell = cell(1);
 
-    not_cell_or_str = not(iscell(match) || ischar(match));
+not_cell_or_str = not(iscell(match) || ischar(match));
 
-    if not_cell_or_str
-        error('The second argument `match` need to be a cell or str')
-    end
+if not_cell_or_str
+    error('The second argument `match` need to be a cell or str')
+end
 
-    if ischar(match)
-        matches = cell(1, 1);
-        matches{1} = match;
-    else
-        matches = match;
-    end
+if ischar(match)
+    matches = cell(1, 1);
+    matches{1} = match;
+else
+    matches = match;
+end
 
-    mlen = numel(matches);
+mlen = numel(matches);
 
-    rm_indexes = [];
-    c = 0;
-    r = 0;
-    include = true;
+rm_indexes = [];
+c = 0;
+r = 0;
+include = true;
 
-    for k = 1:flen
+for k = 1:flen
 
-        for m = 1:mlen
+    for m = 1:mlen
 
-            if ~inCell(xcell, matches{m})
-                is_single_match = mlen == 1;
-                if is_single_match
-                    error('Requested item not found in cell');
-                else
-                    error('Requested `match{%d}` not found in cell');
-                end
-            elseif isequal_ctype(xcell{k}, matches{m})
-                include = false;
-                r = r + 1;
-                break
+        if ~inCell(xcell, matches{m})
+            is_single_match = mlen == 1;
+
+            if is_single_match
+                error('Requested item not found in cell');
+            else
+                error('Requested `match{%d}` not found in cell');
             end
 
+        elseif isequal_ctype(xcell{k}, matches{m})
+            include = false;
+            r = r + 1;
+            break
         end
 
-        if include
-            c = c + 1;
-            newcell{c} = xcell{k};
-        else
-            rm_indexes(r) = k;
-        end
-
-        include = true;
     end
+
+    if include
+        c = c + 1;
+        newcell{c} = xcell{k};
+    else
+        rm_indexes(r) = k;
+    end
+
+    include = true;
+end
 
 end

--- a/test/Util/CellUtils/testPopFromCell.m
+++ b/test/Util/CellUtils/testPopFromCell.m
@@ -1,0 +1,29 @@
+classdef testPopFromCell < matlab.unittest.TestCase
+
+    methods (Test)
+
+        function test_all_cell_argument(~)
+            [newcell] = popFromCell({1, 2, 3}, {2, 3});
+            assert(isequal(newcell, {1}))
+        end
+
+        function test_string_argument(~)
+            [newcell] = popFromCell({'a', 'b'}, 'b');
+            assert(isequal(newcell, {'a'}))
+        end
+
+        function test_empty_argument(~)
+
+            try
+                popFromCell({'a'}, '');
+            catch
+                assert(true)
+                return
+            end
+
+            error("Did not raise error")
+        end
+
+    end
+
+end

--- a/test/Util/CellUtils/test_inCellPartialMatch.m
+++ b/test/Util/CellUtils/test_inCellPartialMatch.m
@@ -1,0 +1,37 @@
+classdef test_inCellPartialMatch < matlab.unittest.TestCase
+
+    properties (TestParameter)
+        tinput = {{sprintf('a\tb\tc'), 'b', 'c'}};
+    end
+
+    methods (Test)
+
+        function test_match_first_index(~, tinput)
+            [is_complete, indexes] = inCellPartialMatch(tinput, {'a b'});
+            assert(is_complete)
+            assert(isequal(indexes, 1))
+        end
+
+        function test_partial_match(~, tinput)
+            [is_complete, indexes] = inCellPartialMatch(tinput, {'a c'});
+            assert(is_complete)
+            assert(isequal(indexes, 1))
+        end
+
+        function test_partial_match_reduced(~, tinput)
+            [is_complete, indexes] = inCellPartialMatch(tinput, {'a c', 'c'});
+            assert(is_complete)
+            assert(isequal(indexes, [1; 1]))
+        end
+
+        function test_partial_match_complete(~, tinput)
+            [is_complete, indexes] = inCellPartialMatch(tinput, {'a c', 'c'}, true);
+            assert(is_complete)
+            assert(iscell(indexes))
+            assert(isequal(indexes{1}, {1}))
+            assert(isequal(indexes{2}, {1, 3}))
+        end
+
+    end
+
+end


### PR DESCRIPTION
The gist of this PR is to 1.fix a broken function ```popfromcell``` and 2. fix an incorrect case handling of an empty match within ```inCellPartialMatch```.

The problems were not picked because the tests were manual and not ported away from the respective examples docstrings. Hence, I also 3. update docstrings and 4. included the proper tests files.

Finally, the files were previously merged using the non-standard linting scheme/config, so I also 5. adjusted the affected files to the "standard toolbox linting" scheme.

Hence, the commits with linting scope should be ignored, since they affect all lines and are just space adjustments.