### PR TITLE
feat(Parsers): Re-use old parser names to new parser, closes #622 #549

### DIFF
--- a/Parser/StarmonDSTParse.m
+++ b/Parser/StarmonDSTParse.m
@@ -38,8 +38,8 @@ function sample_data = StarmonDSTParse( filename, mode )
 try
     sample_data = StaroddiParser(filename,mode);
     return
-catch
-
+catch e
+    warning("Using the old StarmonDSTParse. Please raise an issue in our github page with this warning msg: %s", e.message)
 end
 
 %TODO remove old code below

--- a/Parser/StarmonDSTParse.m
+++ b/Parser/StarmonDSTParse.m
@@ -35,6 +35,14 @@ function sample_data = StarmonDSTParse( filename, mode )
 % along with this program.
 % If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
 %
+try
+    sample_data = StaroddiParser(filename,mode);
+    return
+catch
+
+end
+
+%TODO remove old code below
 narginchk(1,2);
 
 if ~iscellstr(filename)

--- a/Parser/StarmonMiniParse.m
+++ b/Parser/StarmonMiniParse.m
@@ -35,6 +35,14 @@ function sample_data = StarmonMiniParse( filename, mode )
 % along with this program.
 % If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
 %
+try
+    sample_data = StaroddiParser(filename,mode);
+    return
+catch
+    
+end
+
+%TODO: remove old code below
 narginchk(1,2);
 
 if ~iscellstr(filename)

--- a/Parser/StarmonMiniParse.m
+++ b/Parser/StarmonMiniParse.m
@@ -38,8 +38,8 @@ function sample_data = StarmonMiniParse( filename, mode )
 try
     sample_data = StaroddiParser(filename,mode);
     return
-catch
-    
+catch e
+    warning("Using the old StarmonMiniParse. Please raise an issue in our github page with this warning msg: %s", e.message)
 end
 
 %TODO: remove old code below


### PR DESCRIPTION
This is a requirement for transparent usage of the
new Staroddi Parser that supports Mini v0, Mini v1, DST Tilt
and DST CTD.

The reason why is done this way is to still support
old insturments.txt configuration files, database
key:value associations, and to be transparent to the user.