### PR TITLE
feat(bugfix): filter 2d variables in SpikeQC

### DIFF
--- a/AutomaticQC/imosTimeSeriesSpikeQC.m
+++ b/AutomaticQC/imosTimeSeriesSpikeQC.m
@@ -160,8 +160,12 @@ ts_dims = getSampleField(sample_data.variables, 'dimensions');
 c = 1;
 
 for k = 1:length(ts_dims)
+    not_empty = ~isempty(ts_dims{k});
+    not_depth = ~strcmpi(varnames{k}, 'DEPTH');
+    var = getVar(sample_data.variables,varnames{k});
+    is_vector = var && isvector(var);
 
-    if ~isempty(ts_dims{k}) &&~strcmpi(varnames{k}, 'DEPTH')
+    if not_empty && not_depth && is_vector
         ts_variables{c} = varnames{k};
         c = c + 1;
     end


### PR DESCRIPTION
fix #676 by filtering 2d variables in load_timeseries_variables,
which should only select vector variables.