### PR TITLE
fix(graph): fallback for missing the image toolbox

### DIFF
--- a/Graph/checkMooringPlannedDepths.m
+++ b/Graph/checkMooringPlannedDepths.m
@@ -301,9 +301,7 @@ else
     uiwait(hMsgbox);
     
     %select the area to use for comparison
-    rec = drawrectangle(hAxPress);
-    x = [rec.Position(1) rec.Position(1)+rec.Position(3)];
-    delete(rec);
+    [x, ~] = select_points(hAxPress);
     iGood = timeVar >= x(1) & timeVar <= x(2);
 end
 

--- a/Util/select_points.m
+++ b/Util/select_points.m
@@ -1,0 +1,52 @@
+function [x,y] = select_points(hAx)
+% function [x,y] = select_points(hAx)
+%
+% Interactively draw a rectangle in
+% the current axis and extract its own coordinates.
+%
+% Inputs:
+%
+% hAx [graphics.axis.Axes] - a Matlab Axis class 
+%
+% Outputs:
+%
+% x [double] - a row vector of the start/end horizontal 
+%              rectangle positions
+% y [double] - a row vector of the start/end vertical
+%              rectangle positions.
+%
+% Example:
+%
+% %manual evaluation
+% % [x,y] = drawrectangle(gca());
+% % % draw or click with mose
+% % assert(isnumerical(x));
+% % assert(isnumerical(y));
+%
+%
+% author: Rebecca Cowley
+%         hugo.oliveira@utas.edu.au
+%
+if isdeployed || license('test', 'Image_Toolbox')
+    rec = drawrectangle(hAx);
+    x = [rec.Position(1) rec.Position(1) + rec.Position(3)];
+    y = [rec.Position(2) rec.Position(2) + rec.Position(4)];
+    delete(rec);
+else
+    axes(hAx);
+    k = waitforbuttonpress;
+    point1 = get(gca, 'CurrentPoint'); % button down detected
+    finalRect = rbbox; % return figure units
+    point2 = get(gca, 'CurrentPoint'); % button up detected
+    point1 = point1(1, 1:2); % extract x and y
+    point2 = point2(1, 1:2);
+    p1 = min(point1, point2); % calculate locations
+    offset = abs(point1 - point2); % and dimensions
+    x = [p1(1) p1(1) + offset(1) p1(1) + offset(1) p1(1) p1(1)];
+    y = [p1(2) p1(2) p1(2) + offset(2) p1(2) + offset(2) p1(2)];
+    hold on
+    axis manual
+    plot(x, y); % redraw in dataspace units
+end
+
+end


### PR DESCRIPTION
This fix a distribution/compatibility problem
related to the drawrectangle function which is
exclusive of the image processing toolbox.

The fix provide a fallback to the old functionality
in the case the toolbox is not installed/available.


@BecCowley 