### PR TITLE
feat(UI): detailLevel and aliases for instruments

### DIFF
--- a/GUI/instrumentAliases.txt
+++ b/GUI/instrumentAliases.txt
@@ -1,0 +1,5 @@
+%
+% Aliases for instrument names
+%
+% Instrument Exact Name, Alias/Abbreviation
+Seabird SBE19plus, SBE19+

--- a/Preprocessing/depthPP.m
+++ b/Preprocessing/depthPP.m
@@ -334,7 +334,7 @@ iMethodsSamString = false(nDatasets, 4); % logical array with methodsString of p
 iMethodSam        = zeros(nDatasets, 1); % index of selected method within methodsSamString per dataset
 
 for iCurSam = 1:nDatasets
-    descSam{iCurSam} = genSampleDataDesc(sample_data{iCurSam}, 'medium');
+    descSam{iCurSam} = genSampleDataDesc(sample_data{iCurSam});
     
     iMethodsSamString(iCurSam, 4) = true;
     if useItsOwnPresRel(iCurSam)
@@ -353,7 +353,7 @@ for iCurSam = 1:nDatasets
     descOtherSam{iCurSam}{1} = ' - ';
     nOtherSam = length(nearestInsts{iCurSam});
     for iOtherSam = 1:nOtherSam
-        descOtherSam{iCurSam}{iOtherSam+1} = genSampleDataDesc(sample_data{nearestInsts{iCurSam}(iOtherSam)}, 'short');
+        descOtherSam{iCurSam}{iOtherSam+1} = genSampleDataDesc(sample_data{nearestInsts{iCurSam}(iOtherSam)});
     end
 end
 

--- a/Util/readMappings.m
+++ b/Util/readMappings.m
@@ -1,0 +1,49 @@
+function [mappings] = readMappings(file, delimiter)
+% function [mappings] = readMappings(file, delimiter)
+%
+% This read a mapping file, with a predefined delimiter (',').
+%
+% Inputs:
+%
+% file - a file location string
+% delimiter - a field delimiter
+%             default: ','
+%
+% Outputs:
+%
+% mappings - a containers.Map mapping
+%
+% Example:
+%
+% file =
+% [mappings] = readMappings(file)
+% assert()
+%
+% author: hugo.oliveira@utas.edu.au
+%
+
+% Copyright (C) 2020, Australian Ocean Data Network (AODN) and Integrated
+% Marine Observing System (IMOS).
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation version 3 of the License.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.
+% If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
+%
+if nargin < 2
+    delimiter = ',';
+end
+
+nf = fopen(file, 'r');
+raw_read = textscan(nf, '%s', 'Delimiter', delimiter);
+raw_read = raw_read{1};
+mappings = containers.Map(raw_read(1:2:end), raw_read(2:2:end));
+end

--- a/Util/readMappings.m
+++ b/Util/readMappings.m
@@ -1,13 +1,18 @@
 function [mappings] = readMappings(file, delimiter)
 % function [mappings] = readMappings(file, delimiter)
 %
-% This read a mapping file, with a predefined delimiter (',').
+% This read a simple mapping file,
+% which is a two column delimited file.
+% The first column of the file is a key,
+% the second column is a value.
+% The read ignores the `%` matlab comment
+% symbol.
 %
 % Inputs:
 %
-% file - a file location string
-% delimiter - a field delimiter
-%             default: ','
+% file [char] - a file path
+% delimiter [char] - a field delimiter
+%                    Default: ','
 %
 % Outputs:
 %
@@ -15,35 +20,26 @@ function [mappings] = readMappings(file, delimiter)
 %
 % Example:
 %
-% file =
+% file = [toolboxRootPath 'GUI/instrumentAliases.txt'];
 % [mappings] = readMappings(file)
-% assert()
+% assert(mappings.Count>0)
+% keys = mappings.keys;
+% values = mappings.values;
+% assert(ischar(keys{1}))
+% assert(ischar(values{1}))
 %
 % author: hugo.oliveira@utas.edu.au
-%
-
-% Copyright (C) 2020, Australian Ocean Data Network (AODN) and Integrated
-% Marine Observing System (IMOS).
-%
-% This program is free software: you can redistribute it and/or modify
-% it under the terms of the GNU General Public License as published by
-% the Free Software Foundation version 3 of the License.
-%
-% This program is distributed in the hope that it will be useful,
-% but WITHOUT ANY WARRANTY; without even the implied warranty of
-% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-% GNU General Public License for more details.
-%
-% You should have received a copy of the GNU General Public License
-% along with this program.
-% If not, see <https://www.gnu.org/licenses/gpl-3.0.en.html>.
 %
 if nargin < 2
     delimiter = ',';
 end
 
 nf = fopen(file, 'r');
-raw_read = textscan(nf, '%s', 'Delimiter', delimiter);
+raw_read = textscan(nf, '%s', 'Delimiter', delimiter, 'CommentStyle', '%');
 raw_read = raw_read{1};
-mappings = containers.Map(raw_read(1:2:end), raw_read(2:2:end));
+
+try
+    mappings = containers.Map(raw_read(1:2:end), raw_read(2:2:end));
+catch
+    error('Mapping file %s is incomplete.', file);
 end

--- a/toolboxProperties.txt
+++ b/toolboxProperties.txt
@@ -1,26 +1,26 @@
 % filename or ODBC DSN of MS-ACCESS deployment database
 % ex. : /home/ggalibert/OceanDB.mdb or imos-ddb
-toolbox.ddb = 
+toolbox.ddb =
 
 % or full connection details to other kind of deployment database :
 % class name of JDBC database driver
 % ex. : net.ucanaccess.jdbc.UcanaccessDriver
-toolbox.ddb.driver = 
+toolbox.ddb.driver =
 
 % database connection string, must include user and password if required by the database
 % ex. : "jdbc:ucanaccess:///home/ggalibert/OceanDB.mdb;jackcessOpener=org.imos.ddb.CryptCodecOpener"
-toolbox.ddb.connection = 
+toolbox.ddb.connection =
 
 % user's login and password to database
-toolbox.ddb.user = 
-toolbox.ddb.password = 
+toolbox.ddb.user =
+toolbox.ddb.password =
 
-% toolbox execution mode. Values can be 'timeSeries' or 'profile'. 
+% toolbox execution mode. Values can be 'timeSeries' or 'profile'.
 toolbox.mode = timeSeries
 
 % directory which contains netcdf templates
 % (defaults to ./NetCDF/template/)
-toolbox.templateDir = 
+toolbox.templateDir =
 
 % date and time formats used internally and for GUI display
 toolbox.dateFormat = dd mmm yyyy
@@ -28,6 +28,22 @@ toolbox.timeFormat = yyyy-mm-ddTHH:MM:SS
 
 % QC set in use - see section 6.2 of the IMOS NetCDF User's Manual
 toolbox.qc_set = 1
+
+%Instrument display options
+% An alias file to change instrument visual names based on matched
+% entries.
+% [matched instrument maker/model], [display_name]
+toolbox.instrumentAliases = GUI/instrumentAliases.txt
+
+%Instrument detail level display options. This set the instrument metadata
+details. If instrumentAliases entries are found, [maker model] is substitute
+to the respective entry in toolbox.instrumentAliases
+% name-only - [maker model]
+% short - [maker model depth]
+% medium - [maker model serial_number depth filename]
+% full - [maker model serial number depth time_range filename]
+% id - [file serial depth]
+toolbox.detailLevel = full
 
 % format in which all dates should be exported in NetCDF attributes
 exportNetCDF.dateFormat = yyyy-mm-ddTHH:MM:SSZ
@@ -43,7 +59,7 @@ autoQCManager.autoQCDefaultChain.profile = imosImpossibleDateQC imosImpossibleLo
 autoQCManager.autoQCChain.timeSeries = imosImpossibleDateQC imosImpossibleLocationSetQC imosInOutWaterQC imosGlobalRangeQC imosImpossibleDepthQC imosSalinityFromPTQC imosSideLobeVelocitySetQC imosTiltVelocitySetQC imosHorizontalVelocitySetQC imosVerticalVelocityQC imosCorrMagVelocitySetQC imosHistoricalManualSetQC
 autoQCManager.autoQCChain.profile = imosImpossibleDateQC imosImpossibleLocationSetQC imosInOutWaterQC imosGlobalRangeQC imosImpossibleDepthQC imosSalinityFromPTQC imosHistoricalManualSetQC
 
-% prompt for preprocessing (if false, 
+% prompt for preprocessing (if false,
 % preprocessing routines are not executed)
 preprocessManager.preprocessPrompt = true
 
@@ -56,35 +72,35 @@ preprocessManager.preprocessChain.timeSeries = depthPP salinityPP oxygenPP absiD
 preprocessManager.preprocessChain.profile = depthPP salinityPP oxygenPP
 
 % file status dialog formatting styles
-% can be one of 'bold', 'normal', 'italic', or an HTML colour (e.g. 'red', 
+% can be one of 'bold', 'normal', 'italic', or an HTML colour (e.g. 'red',
 % 'blue' etc)
 dataFileStatusDialog.invalidFileNameFormat = red
 dataFileStatusDialog.noFileFormat          = bold
 dataFileStatusDialog.multipleFileFormat    = italic
 
 % last selected values for start dialog
-startDialog.dataDir.timeSeries = 
-startDialog.dataDir.profile = 
-startDialog.fieldTrip.timeSeries = 
-startDialog.fieldTrip.profile = 
-startDialog.lowDate.timeSeries = 
-startDialog.lowDate.profile = 
-startDialog.highDate.timeSeries = 
-startDialog.highDate.profile = 
+startDialog.dataDir.timeSeries =
+startDialog.dataDir.profile =
+startDialog.fieldTrip.timeSeries =
+startDialog.fieldTrip.profile =
+startDialog.lowDate.timeSeries =
+startDialog.lowDate.profile =
+startDialog.highDate.timeSeries =
+startDialog.highDate.profile =
 
 % last selected directory for manual data import
-importManager.manualDir = 
+importManager.manualDir =
 
 % last selected directory for file export
-exportDialog.defaultDir = 
+exportDialog.defaultDir =
 
-% prompt user to select parser if an appropriate one 
+% prompt user to select parser if an appropriate one
 % cannot be found (if false, the data is not imported)
 importManager.noParserPrompt = true
 
 % last selected directory for saving graphs as images
 saveGraph.noPrompt  = false
-saveGraph.exportDir = 
+saveGraph.exportDir =
 saveGraph.imgType   = png
 
 % visual QC plots export properties


### PR DESCRIPTION
These changes permit the user to set
the level of detail shown on all UI elements related
to instrument metadata description.

Two new options are provided in the toolboxProperties,
`instrumentAliases` and `detailLevel`.

instrumentAliases modify the display name of instruments
in the UI to the entries presented within
the GUI/instrumentAliases.txt file.

detailLevel modify the data description in all UI elements
to match several named options.

See the updated toolboxProperties.txt file for details.