### PR TITLE
some new test utilities 

### DIFF
--- a/Util/File/read_until_match.m
+++ b/Util/File/read_until_match.m
@@ -1,0 +1,109 @@
+function [clines, number_of_lines] = read_until_match(fid, pattern, is_regex, preallocsize)
+%function [clines, number_of_lines] = read_until_match(fid, pattern, is_regex, preallocsize)
+%
+% Read a file, line by line, until a pattern is found, returning
+% all lines read and the total number of lines.
+% The result is empty (total number of lines) if no match is found.
+%
+% Inputs:
+%
+% fid - numerical file id
+% pattern - the string pattern to match
+% is_regex - the string pattern is a regex.
+%            Default: False.
+% preallocsize - the preallocation length (N) of the clines cell (1xN).
+%
+%
+% Outputs:
+%
+% clines - a cell of strings with all lines read until the match.
+% number_of_lines - the total number of lines read
+%
+% Example:
+% % create
+% tmpfile = [tempdir 'test_read_until_match.txt'];
+% fid = fopen(tmpfile,'w');
+% fprintf(fid,'%c\n%c\n%c\n',['a','X','c']);
+% fclose(fid);
+%
+% % full read
+% fid = fopen(tmpfile,'r');
+% [text,lc] = read_until_match(fid,'X');
+% assert(isequal(text{1},'a'))
+% assert(isequal(text{2},'X'))
+% assert(lc==2)
+%
+% % partial read
+% fid = fopen(tmpfile,'r');
+% [text,lc] = read_until_match(fid,'a');
+% assert(isequal(text{1},'a'))
+% assert(length(text)==1)
+% assert(lc==1)
+%
+% % empty case
+% fid = fopen(tmpfile,'r');
+% [text,lc] = read_until_match(fid,'Z');
+% assert(isempty(text));
+% assert(lc==4)
+%
+% author: hugo.oliveira@utas.edu.au
+%
+narginchk(2, 4)
+
+if nargin < 3
+    is_regex = false;
+end
+
+if nargin < 4
+    stacksize = 1000;
+end
+
+if is_regex
+    match_fun = @regexp;
+else
+    match_fun = @contains;
+end
+
+[text, eof] = read_line(fid);
+if eof
+    number_of_lines = 0;
+    clines = {};
+    return
+else
+    number_of_lines = 1;
+    clines = cell(1, stacksize);
+    clines{1} = text;
+end
+
+while ~eof
+    matched = match_fun(text, pattern);
+    if matched
+        break
+    end
+    [text, eof] = read_line(fid);
+    number_of_lines = number_of_lines +1;
+    clines{number_of_lines} = text;
+end
+
+if ~matched
+    clines = {};
+else
+    clines=clines(1:number_of_lines);
+end
+
+end
+
+function [text, eof] = read_line(fid)
+%
+% read a line from a matlab
+% file identification integer.
+%
+eof = false;
+text = fgetl(fid);
+
+if isnumeric(text)
+    eof = true;
+    return
+end
+
+end

--- a/Util/Random/random_between.m
+++ b/Util/Random/random_between.m
@@ -1,0 +1,53 @@
+function [arr] = random_between(a,b,n,type)
+% function [arr] = random_between(a,b,n,type)
+%
+% Draw n numbers from the a-b range (inclusive)
+%
+% Inputs:
+%
+% a - start of random range (inclusive)
+% b - end of random range (inclusive)
+% n - the number of draws
+% type - optional type string.
+%      - default: 'double'
+%      - available: 'double','int', or 'logical'.
+% Outputs:
+%
+% arr - an array of size 1xn with random numbers in the ]a,b[ open interval.
+%
+% Example:
+% %from: https://www.mathworks.com/help/matlab/math/floating-point-numbers-within-specific-range.html
+% arr=random_between(0,1,10);
+% assert(min(arr)>0 && max(arr)<1)
+%
+% % random int
+% arr=random_between(0,5,100,'int');
+% assert(all(double(int64(arr))==arr))
+%
+% % random logical
+% arr=random_between(0,1,100,'logical');
+% assert(min(arr)==0 && max(arr)==1)
+%
+% % random constant
+% arr=random_between(1,1,10,'int');
+% assert(isequal(arr,ones(1,10)));
+%
+%
+% author: hugo.oliveira@utas.edu.au
+%
+
+if nargin>3
+	if contains(type,'int')
+		arr = randi([a b],1,n);
+		return
+	end
+	if contains(type,'logical')
+		arr = logical(randi([0,1],1,n));
+		return
+	end
+end
+if nargin<3
+	n = 1;
+end
+arr = (b-a).*rand(1,n) + a;
+end

--- a/Util/Random/random_names.m
+++ b/Util/Random/random_names.m
@@ -1,0 +1,42 @@
+function rnames = random_names(n, len)
+%function rnames = random_names(n, len)
+%
+% Create `n` random names in a cell, where each
+% name is `len` limited.
+%
+% Inputs:
+%
+%  n - the number of names to create
+%  len - the length of each name
+%
+% Outputs:
+%
+%  rnames - 1xn cell with 1x[len] sized strings
+%
+% Example:
+%
+% rnames = random_names(1);
+% assert(iscell(rnames))
+% assert(~isempty(rnames))
+% assert(~isempty(rnames{1}))
+% assert(isstr(rnames{1}))
+%
+% author: hugo.oliveira@utas.edu.au
+%
+
+if nargin < 1
+    n = 1;
+    len = 10;
+elseif nargin < 2
+    len = 10;
+end
+
+dict = '123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789abcdefghijklmnopqrstuvwxyz';
+drange = [1, numel(dict)];
+rnames = cell(1, n);
+
+for k = 1:n
+    rnames{k} = dict(randi(drange, 1, len));
+end
+
+end

--- a/Util/Random/random_numeric_typefun.m
+++ b/Util/Random/random_numeric_typefun.m
@@ -1,0 +1,34 @@
+function rntype = random_numeric_typefun(n)
+%function rntype= random_numeric_typefun(n)
+%
+% Create `n` random numeric function handles in a cell.
+%
+% Inputs:
+%
+%  n - the number of names to create
+%
+% Outputs:
+%
+%  rntype - 1xn cell with random numerical function handle types
+%
+% Example:
+%
+% rntype = random_numeric_typefun(1);
+% assert(length(rntype)==1);
+% assert(isfunctionhandle(rntype{1}));
+%
+% author: hugo.oliveira@utas.edu.au
+%
+if nargin < 1
+    n = 1;
+end
+
+dict = {@uint8, @uint16, @uint32, @uint64, @int8, @int16, @int32, @int64, @single, @double, @logical};
+drange = [1, numel(dict)];
+rntype = cell(1, n);
+
+for k = 1:n
+    rntype{k} = dict{randi(drange)};
+end
+
+end

--- a/Util/TestUtils/check_docstrings.m
+++ b/Util/TestUtils/check_docstrings.m
@@ -1,0 +1,60 @@
+function [ok, wrong_files] = check_docstrings(folder)
+% function [ok, wrong_files] = check_docstrings(folder)
+%
+% Check all matlab source file IMOS docstrings in a folder.
+%
+% Inputs:
+% 
+% folder [str] - a string with the folder location.
+%
+% Outputs:
+% 
+% ok [bool] - All docstrings are fine.
+% wrong_files - A cell where the evaluation of the docstring failed.
+%
+% Example:
+%
+% folder = [toolboxRootPath 'Util/TestUtils']
+% [ok,wrong_files] = check_docstrings(folder);
+% assert(ok)
+% assert(isempty(wrong_files));
+%
+% author: hugo.oliveira@utas.edu.au
+%
+ok = false;
+wrong_files = {};
+
+files = rdir(folder);
+srcfiles = cell2mat(cellfun(@is_matlab,files,'UniformOutput',false));
+matlab_files = files(srcfiles);
+self_calling = contains(matlab_files,'check_docstrings.m');
+if any(self_calling)
+	matlab_files(self_calling) = [];
+end
+nfiles = numel(matlab_files);
+
+oks = zeros(1,nfiles);
+for k=1:nfiles
+	file = matlab_files{k};
+	fprintf('%s: checking %s\n',mfilename,file)
+	[oks(k),~] = test_docstring(file);
+end
+
+failed = ~all(oks);
+if failed
+	ok = false;
+else
+	ok = true;
+end
+
+report = nargout>1 && failed;
+if report
+	wrong_files = matlab_files(~oks);
+end
+
+end
+
+function is_matlab = is_matlab(filestr)
+	[~,~,ext] = fileparts(filestr);
+	is_matlab = strcmp(ext,'.m');
+end

--- a/Util/TestUtils/comment_eval_wrapper.m
+++ b/Util/TestUtils/comment_eval_wrapper.m
@@ -1,0 +1,98 @@
+function [ok, msg] = comment_eval_wrapper(cell_of_strings, line_offset, dbreak)
+%function [ok, msg] = comment_eval_wrapper(cell_of_strings)
+%
+% a closure to evaluate commented string entries
+% inside a cell. The function stops at the first
+% empty entry in a cell and ignore all non comments
+% entries.
+%
+% Inputs:
+%
+% cell_of_strings - a cell of strings to be evaluated.
+% line_offset - The line offset of the commented string.
+%               Default: 0.
+% dbreak - boolean to break/keyboard at a wrong evaluation.
+%
+% Outputs:
+%
+% ok - if the evaluation was fine.
+% msg - the fail msg if any.
+%
+% Example:
+%
+% [ok,msg] = comment_eval_wrapper({'%a=10;','%b=a-10.;'});
+% assert(ok)
+% assert(isempty(msg))
+%
+% % Manual testing below, since nested calls will trigger a fail
+% % [ok,msg] = comment_eval_wrapper({'%a?x=10;'});
+% % assert(~ok)
+% % assert(contains(msg,'Error:'));
+%
+% author: hugo.oliveira@utas.edu.au
+%
+if nargin < 2
+    line_offset = 0;
+end
+BOL_re = '(\s*%\s*)';
+EXPR_re = '(?<expr>.+$)';
+re = [BOL_re EXPR_re];
+
+ok = false;
+msg = '';
+
+nentries = length(cell_of_strings);
+k = 1;
+
+while true
+
+    if k > nentries
+        break
+    end
+
+    etext = cell_of_strings{k};
+
+    if isempty(etext)
+        break
+    else
+        match = regexpi(etext, re, 'names');
+
+        if ~isempty(match)
+            etext = match.expr;
+
+            try
+                eval(etext)
+            catch err
+                msg = sprintf('{line(%d)}:%%%s -> %s', line_offset + k, etext, err.message);
+                if dbreak
+                    docstring_stack(cell_of_strings, k, msg)
+                    keyboard;
+                else
+                    disp(msg)
+                end
+
+                return
+            end
+
+        end
+
+    end
+
+    k = k + 1;
+end
+
+ok = true;
+end
+
+function docstring_stack(cell_of_strings, errind, msg)
+%function stop_at_docstring_error(cell_of_strings, errind, msg)
+%
+% Display/debug the erroed docstring
+%
+disp('%->Docstring start')
+
+for c = 1:errind
+    disp(cell_of_strings{c})
+end
+disp(msg)
+end

--- a/Util/TestUtils/test_docstring.m
+++ b/Util/TestUtils/test_docstring.m
@@ -1,0 +1,72 @@
+function [ok, msg] = test_docstring(filename,dbreak)
+% function [ok,msg] = test_docstring(filename,dbreak)
+%
+% Test the Example block of an IMOS source code matlab file.
+%
+% The function works by evaluating everything
+% between the `% Example:` line and the
+% `% author:` line of a help block.
+%
+% Inputs:
+%
+% filename - the matlab file
+% dbreak - a boolean to interactively stop at a
+%          wrong docstring evaluation.
+%
+% Outputs:
+%
+% ok - if the test succeeded
+% msg - the fail msg
+%
+% Example:
+% % test used functions
+% [ok,msg] = test_docstring('comment_eval_wrapper');
+% assert(ok)
+% assert(isempty(msg))
+% [ok,msg] = test_docstring('read_until_match');
+% assert(ok)
+% assert(isempty(msg))
+%
+% author: hugo.oliveira@utas.edu.au
+%
+narginchk(1, 2)
+if nargin<2
+    dbreak = false;
+end
+
+fid = fopen(filename, 'r');
+
+if fid < 0
+    fullfile = which(filename);
+    fid = fopen(fullfile, 'r');
+
+    if fid < 0
+        error('cant read %s', filename);
+    end
+
+end
+
+use_regex = true;
+docstring_start_re = '^\s?%\s?Example[s]?:';
+docstring_end_re = '^\s?%\s?author[s]?:';
+%TODO: when licenses are removed from all source files, include the one below.
+%docstring_end_re = '^(?!\s?%).+';
+
+[docstring_text, block_start_line] = read_until_match(fid, docstring_start_re, use_regex);
+if isempty(docstring_text)
+    ok = false;
+    msg = sprintf('No docstring Example block found in %s',filename);
+    return
+end
+
+text_to_evaluate = read_until_match(fid, docstring_end_re, use_regex);
+text_to_evaluate = text_to_evaluate(1:end-1); % remove docstring_end_re match
+
+[ok, msg] = comment_eval_wrapper(text_to_evaluate, block_start_line, dbreak);
+
+if ~ok
+    [~, file] = fileparts(filename);
+    msg = [file msg];
+end
+
+end


### PR DESCRIPTION
These are some utilities to reduce some manual testing, code size in test classes, and also to avoid write test classes in some cases.

`test_docstring` enable us to use the function docstring as tests. It reads the docstring blocks within the `%Example:`
subblock and evaluate every expression. It's simple (no multiline evaluation), but help us to reduce code size and make sure docstrings are updated.

EDIT: moved some commits to another branch to be self contained.