### PR TITLE
fix: build --matlab_path argument parsing, fixes 

### DIFF
--- a/build.py
+++ b/build.py
@@ -4,7 +4,7 @@
 Support both Linux and Windows. See the `--arch` flag.
 
 Usage:
-    build.py [--arch=<architecture> --check-repo-only --dry-run --build-java-deps  --root_path=<imostoolboxpath> --matlab_path=<mccpath> --dist_path=<distpath>]
+    build.py [--arch=<architecture> --check-repo-only --dry-run --build-java-deps  --root_path=<imostoolboxpath> --matlab_path=<matlabpath> --dist_path=<distpath>]
 
 Options:
     -h --help    Show this screen.


### PR DESCRIPTION
This is a very low priority PR - it just fixes an argument parsing for the matlab path. We handle most of the paths automatic now and this flag is highly optional and only used for very unusual Matlab paths.

