### PR TITLE
Add instrument info text string to spikeWindow GUI

### DIFF
--- a/AutomaticQC/imosTimeSeriesSpikeQC.m
+++ b/AutomaticQC/imosTimeSeriesSpikeQC.m
@@ -206,6 +206,7 @@ time = sample_data.dimensions{timeId}.data;
 
 postqc.variables = cell(1, n_ts_vars);
 postqc.dimensions = sample_data.dimensions;
+postqc.meta = sample_data.meta;
 
 if ~isempty(burst_interval)
     postqc.burst_precision = precisionBounds(burst_interval / 86400);

--- a/GUI/spikeWindow.m
+++ b/GUI/spikeWindow.m
@@ -51,7 +51,7 @@ classdef spikeWindow < handle
             obj.spike_classifiers = loadSpikeClassifiers(obj.opts_file, obj.has_burst);
 
             try
-                obj.instrument_name = [obj.sample_data.meta.instrument_make ':' obj.sample_data.meta.instrument_model];
+                obj.instrument_name = genSampleDataDesc(sample_data, 'short');
             catch
                 obj.instrument_name = '';
             end
@@ -72,8 +72,14 @@ classdef spikeWindow < handle
         end
 
         function init_panel(obj, instrument)
-            obj.panel_opts = {'Parent', obj.ui_window, 'title', sprintf('%s - select variables/methods for Spike detection', instrument), 'Units', 'normalized', 'Position', [obj.panelMargin, obj.cancelSize, 1 - obj.panelMargin * 2, 1 - obj.cancelSize - obj.panelMargin]};
+            obj.panel_opts = {'Parent', obj.ui_window, ...
+                'title', 'Select variables/methods for Spike detection', ...
+                'Units', 'normalized', ...
+                'Position', [obj.panelMargin, obj.cancelSize, 1 - obj.panelMargin * 2, 1 - obj.cancelSize - obj.panelMargin - obj.okSize]};
             obj.ui_panel = uipanel(obj.panel_opts{:});
+            uicontrol(obj.ui_window, 'Style', 'text', 'String', obj.instrument_name, ...
+                'Units', 'normalized', ...
+                'Position', [obj.panelMargin, 1 - obj.cancelSize - obj.panelMargin, 1 - obj.panelMargin * 2, obj.okSize]);
         end
 
         function pos = move_pos_down(obj, pos)

--- a/IMOS/finaliseData.m
+++ b/IMOS/finaliseData.m
@@ -50,11 +50,11 @@ function sam = finaliseData(sam, rawFiles, flagVal, toolboxVersion)
   mode = readProperty('toolbox.mode');
   
   % turn raw data files a into semicolon separated string
-  rawFiles = cellfun(@(x)([x ';']), rawFiles, 'UniformOutput', false);
+  rawFiles = strjoin(rawFiles, ';');
   
   sam.meta.log           = {};
   sam.meta.QCres         = {};
-  sam.meta.raw_data_file = [rawFiles{:}];
+  sam.meta.raw_data_file = rawFiles;
   
   if isfield(sam.meta, 'site')
       if ~isempty(fieldnames(sam.meta.site)), sam.meta.site_name = sam.meta.site.SiteName; end

--- a/Util/genSampleDataDesc.m
+++ b/Util/genSampleDataDesc.m
@@ -74,7 +74,11 @@ timeRange = ['from ' datestr(time_coverage_start, timeFmt) ' to ' ...
     datestr(time_coverage_end,   timeFmt)];
 
 try
-    filename = sam.toolbox_input_file;
+    if isfield(sam, 'toolbox_input_file')
+        filename = sam.toolbox_input_file;
+    else
+        filename = sam.meta.raw_data_file;
+    end
 catch
     filename = 'Unknown';
 end


### PR DESCRIPTION
 This necessitated copying the meta struct which contains make/model info. Use genSampleDataDesc to create instrument string instead of concatenating make/model info. Final instrument info string is display above the uipanel.