### PR TITLE
(Fix) Error velocity QC should be & not |

### DIFF
--- a/AutomaticQC/imosErrorVelocitySetQC.m
+++ b/AutomaticQC/imosErrorVelocitySetQC.m
@@ -98,7 +98,7 @@ flags = ones(sizeCur, 'int8')*rawFlag;
 iNaNerv = isnan(erv);
 % Run QC NEED TO edit this as it should be the mean +/- the threshold.
 ervm = nanmean(erv(:));
-iPass = erv >= ervm - err_vel | erv <= ervm + err_vel;
+iPass = erv >= ervm - err_vel & erv <= ervm + err_vel;
 iPass(iNaNerv) = true;
 
 iFail = ~iPass;


### PR DESCRIPTION
Originally submitted by @BecCowley :

> Should have an & to find error velocity values that are between the two extremes.

Supersedes #756 