### PR TITLE
docs: remove old link and add link to wiki

### DIFF
--- a/AutomaticQC/imosSideLobeVelocitySetQC.m
+++ b/AutomaticQC/imosSideLobeVelocitySetQC.m
@@ -202,7 +202,8 @@ end
 
 % calculate contaminated depth
 %
-% http://www.nortekusa.com/usa/knowledge-center/table-of-contents/doppler-velocity#Sidelobes
+% Link to the wiki:
+% https://github.com/aodn/imos-toolbox/wiki/QCProcedures#adcp-side-lobe-contamination-test---imossidelobevelocitysetqc---compulsory
 %
 % by default substraction of 1/2*BinSize to the non-contaminated height in order to be
 % conservative and be sure that the first bin below the contaminated depth


### PR DESCRIPTION
The link in this script is not working anymore. Instead, it'll be best to point to the wiki so there is only one place holder to update when we need to update.

I'm just about to update the [wiki for the corresponding section](https://github.com/aodn/imos-toolbox/wiki/QCProcedures#adcp-side-lobe-contamination-test---imossidelobevelocitysetqc---compulsory)