### PR TITLE
Ocean contour updates

### DIFF
--- a/Util/+IMOS/+resolve/imos_type.m
+++ b/Util/+IMOS/+resolve/imos_type.m
@@ -35,6 +35,13 @@ if ~ischar(imos_name)
 end
 
 params = IMOS.params();
+
+[is_numbered,base_name] = IMOS.resolve.is_numbered_var(imos_name);
+
+if is_numbered
+    imos_name = base_name;
+end
+
 [name_exist, name_ind] = inCell(params.name, imos_name);
 
 if ~name_exist

--- a/Util/+IMOS/+resolve/is_numbered_var.m
+++ b/Util/+IMOS/+resolve/is_numbered_var.m
@@ -1,0 +1,8 @@
+function [bool,plain_name] = is_numbered_var(name)
+    plain_name = name;
+    sname = split(name,'_');
+    bool = numel(sname) == 2 && ~isnan(str2double(sname{2}));    
+    if bool
+        plain_name = sname{1};
+    end
+end

--- a/Util/+IMOS/+templates/dimensions.m
+++ b/Util/+IMOS/+templates/dimensions.m
@@ -5,6 +5,7 @@ classdef  dimensions
 		profile = profile_dims();
 		ad_profile = ad_profile_dims();
 		adcp = adcp_dims();
+		adcp_enu = adcp_enu_dims();
 	end
 end
 
@@ -29,4 +30,9 @@ end
 function [dimensions] = adcp_dims()
 dimensions = timeseries_dims();
 dimensions{2} = struct('name','DIST_ALONG_BEAMS','typeCastFunc',getIMOSType('DIST_ALONG_BEAMS'),'data',[]);
+end
+
+function [dimensions] = adcp_enu_dims()
+dimensions = timeseries_dims();
+dimensions{2} = struct('name','HEIGHT_ABOVE_SENSOR','typeCastFunc',getIMOSType('HEIGHT_ABOVE_SENSOR'),'data',[]);
 end

--- a/Util/+IMOS/gen_dimensions.m
+++ b/Util/+IMOS/gen_dimensions.m
@@ -6,7 +6,7 @@ function dimensions = gen_dimensions(mode, ndims, d_names, d_types, d_datac, var
 %
 % Inputs:
 %
-%  mode [str] - ['timeSeries','profile','adcp_raw','adcp_remapped'].
+%  mode [str] - ['timeSeries','profile','adcp'].
 %  If empty, 'timeSeries' is used.
 %
 %  ndims [int] - number of dimensions.
@@ -109,20 +109,10 @@ if got_any_name
 end
 
 if nargin < 2
-
-    if strcmpi(mode, 'timeSeries')
-        dimensions = IMOS.templates.dimensions.timeseries;
+    try
+        dimensions = IMOS.templates.dimensions.(mode);
         return
-    elseif strcmpi(mode, 'profile')
-        dimensions = IMOS.templates.dimensions.profile;
-        return
-    elseif strcmpi(mode, 'ad_profile')
-        dimensions = IMOS.templates.dimensions.ad_profile;
-        return
-    elseif strcmpi(mode, 'adcp')
-        dimensions = IMOS.templates.dimensions.adcp;
-        return
-    else
+    catch
         ndims = 1;
         d_names = randomNames();
         d_types = randomNumericTypefun();


### PR DESCRIPTION
As mentioned over email in multiple conversations, here are some updates related to the OceanContour parser. 
The changes here include bin mapping support and you can test that with this file (remove the .txt extension) :
[S101916A007_USG_SIG1000_avgd.ad2cp.txt](https://github.com/aodn/imos-toolbox/files/8865796/S101916A007_USG_SIG1000_avgd.ad2cp.txt)

What is missing here is the primary test to call the docstrings or test individual components and files. I think there are two options here for devs: A. improve the docstring parser to be able to parse multiple docstrings in a single source file, or B. write a unit test file that will test the individual components/parser options/etc. 

