### PR TITLE
Ocean contour updates

### DIFF
--- a/Parser/OceanContour/OceanContour.m
+++ b/Parser/OceanContour/OceanContour.m
@@ -447,7 +447,7 @@ classdef OceanContour
             %
             % %read from netcdf
             % file = [toolboxRootPath 'data/testfiles/netcdf/Nortek/OceanContour/Signature/s500_enu_avg.nc'];
-            % [sample_data] = readOceanContour(file);
+            % [sample_data] = OceanContour.readOceanContourFile(file);
             % assert(strcmpi(sample_data{1}.meta.instrument_model,'Signature500'))
             % assert(isequal(sample_data{1}.meta.instrument_avg_interval,60))
             % assert(isequal(sample_data{1}.meta.instrument_sample_interval,600))
@@ -458,7 +458,7 @@ classdef OceanContour
             %
             % % read from matfile
             % file = [toolboxRootPath 'data/testfiles/mat/Nortek/OceanContour/Signature/s500_enu_avg.mat'];
-            % [sample_data] = readOceanContour(file);
+            % [sample_data] = OceanContour.readOceanContourFile(file);
             % assert(strcmpi(sample_data{1}.meta.instrument_model,'Signature500'))
             % assert(isequal(sample_data{1}.meta.instrument_avg_interval,60))
             % assert(isequal(sample_data{1}.meta.instrument_sample_interval,600))
@@ -548,12 +548,16 @@ classdef OceanContour
 
                 meta.magDec = get_att('magDec');
                 custom_magnetic_declination = logical(meta.magDec);
-                meta.binMapping = get_att('binMapping');
-                binmapped = logical(meta.binMapping);                                               
+                try
+                    meta.binMapping = get_att('binMapping');
+                    binmapped = logical(meta.binMapping);
+                catch
+                    binmapped = false;
+                end
+                                
                 %Now that we know some preliminary info, we can load the variable
                 % name mappings and the list of variables to import.
-                
-                
+                                
                 var_mapping = OceanContour.get_varmap(ftype, group_name, nBeams, custom_magnetic_declination,binmapped);
                 import_mapping = OceanContour.get_importmap(nBeams, custom_magnetic_declination);
 
@@ -568,7 +572,7 @@ classdef OceanContour
                     meta.dim_meta = data_metadata.(group_name).Dimensions;
                     meta.var_meta = data_metadata.(group_name).Variables;
                     gid = dataset_groups(k);
-                    get_var = @(x)(nc_get_var(gid, var_mapping.(x)));                   
+                    get_var = @(x)(nc_get_var(gid, var_mapping.(x))); 
                 else
                     fname = getindex(dataset_groups, k);
                     get_var = @(x)(transpose(matdata.(fname).(var_mapping.(x))));

--- a/Util/+IMOS/+resolve/imos_type.m
+++ b/Util/+IMOS/+resolve/imos_type.m
@@ -35,6 +35,13 @@ if ~ischar(imos_name)
 end
 
 params = IMOS.params();
+
+[is_numbered,base_name] = IMOS.resolve.is_numbered_var(imos_name);
+
+if is_numbered
+    imos_name = base_name;
+end
+
 [name_exist, name_ind] = inCell(params.name, imos_name);
 
 if ~name_exist

--- a/Util/+IMOS/+resolve/is_numbered_var.m
+++ b/Util/+IMOS/+resolve/is_numbered_var.m
@@ -1,0 +1,8 @@
+function [bool,plain_name] = is_numbered_var(name)
+    plain_name = name;
+    sname = split(name,'_');
+    bool = numel(sname) == 2 && ~isnan(str2double(sname{2}));    
+    if bool
+        plain_name = sname{1};
+    end
+end

--- a/Util/+IMOS/+templates/dimensions.m
+++ b/Util/+IMOS/+templates/dimensions.m
@@ -5,6 +5,7 @@ classdef  dimensions
 		profile = profile_dims();
 		ad_profile = ad_profile_dims();
 		adcp = adcp_dims();
+		adcp_enu = adcp_enu_dims();
 	end
 end
 
@@ -29,4 +30,9 @@ end
 function [dimensions] = adcp_dims()
 dimensions = timeseries_dims();
 dimensions{2} = struct('name','DIST_ALONG_BEAMS','typeCastFunc',getIMOSType('DIST_ALONG_BEAMS'),'data',[]);
+end
+
+function [dimensions] = adcp_enu_dims()
+dimensions = timeseries_dims();
+dimensions{2} = struct('name','HEIGHT_ABOVE_SENSOR','typeCastFunc',getIMOSType('HEIGHT_ABOVE_SENSOR'),'data',[]);
 end

--- a/Util/+IMOS/gen_dimensions.m
+++ b/Util/+IMOS/gen_dimensions.m
@@ -6,7 +6,7 @@ function dimensions = gen_dimensions(mode, ndims, d_names, d_types, d_datac, var
 %
 % Inputs:
 %
-%  mode [str] - ['timeSeries','profile','adcp_raw','adcp_remapped'].
+%  mode [str] - ['timeSeries','profile','adcp'].
 %  If empty, 'timeSeries' is used.
 %
 %  ndims [int] - number of dimensions.
@@ -109,20 +109,10 @@ if got_any_name
 end
 
 if nargin < 2
-
-    if strcmpi(mode, 'timeSeries')
-        dimensions = IMOS.templates.dimensions.timeseries;
+    try
+        dimensions = IMOS.templates.dimensions.(mode);
         return
-    elseif strcmpi(mode, 'profile')
-        dimensions = IMOS.templates.dimensions.profile;
-        return
-    elseif strcmpi(mode, 'ad_profile')
-        dimensions = IMOS.templates.dimensions.ad_profile;
-        return
-    elseif strcmpi(mode, 'adcp')
-        dimensions = IMOS.templates.dimensions.adcp;
-        return
-    else
+    catch
         ndims = 1;
         d_names = randomNames();
         d_types = randomNumericTypefun();

--- a/test/Parser/GenericParser/testOceanContour.m
+++ b/test/Parser/GenericParser/testOceanContour.m
@@ -1,0 +1,47 @@
+classdef testOceanContour < matlab.unittest.TestCase
+
+    % Test Reading Nortek Signature files output by OceanContour software
+    % with the OceanContour
+    % function.
+    %
+    % author: laurent.besnard@utas.edu.au
+    %
+    % TODO: understand why fillValues for s500 and s1000 are different by a
+    % factor 10
+        
+
+    properties (TestParameter)
+        mode = {'timeSeries'};
+        oceancontour_sig500_file = files2namestruct(rdir([toolboxRootPath 'data/testfiles/netcdf/Nortek/OceanContour/Signature/sig500']));
+        oceancontour_sig1000_file = files2namestruct(rdir([toolboxRootPath 'data/testfiles/netcdf/Nortek/OceanContour/Signature/sig1000']));
+    end
+
+    methods (Test)
+
+        function testOceanContourSig500(~, oceancontour_sig500_file)
+            data = OceanContour.readOceanContourFile(oceancontour_sig500_file);
+            assert(strcmp(data{1}.meta.instrument_model,'Signature500'));
+            assert(strcmp(data{1}.meta.instrument_make,'Nortek'));
+            assert(strcmp(data{1}.meta.coordinate_system,'ENU'));
+            assert(data{1}.meta.beam_angle==25);
+            assert(round(mean(data{1,1}.variables{1,5}.data)) == 19)  % TEMP var check
+             
+            tolerance = 0.001;
+            assert(abs(min(data{1,1}.variables{1,16}.data(:,1)) - -32.7680) < tolerance);  % UCUR var check. fillvalue seems to be -32.7680
+        end
+        
+        function testOceanContourSig1000(~, oceancontour_sig1000_file)
+            data = OceanContour.readOceanContourFile(oceancontour_sig1000_file);
+            assert(strcmp(data{1}.meta.instrument_model,'Signature1000'));
+            assert(strcmp(data{1}.meta.instrument_make,'Nortek'));
+            assert(strcmp(data{1}.meta.coordinate_system,'ENU'));
+            assert(data{1}.meta.beam_angle==25);
+            assert(round(mean(data{1,1}.variables{1,5}.data)) == 20)  % temperature var check
+            
+            tolerance = 0.001;
+            assert(abs(min(data{1,1}.variables{1,16}.data(:,1)) - -3.27680) < tolerance);  % UCUR var check. fillvalue seems to be -3.27680
+        end
+    end
+
+end
+


### PR DESCRIPTION
@ocehugo added commits to your og PR https://github.com/aodn/imos-toolbox/pull/788 which can be closed.

The tests files used by the unittest need to be uploaded to the imos-toobox bucket, which I'll do once merged.

However I dug a bit in the sample files provided and had a bit of a concern.

The s500 sample file provided (s500_enu_avg.nc) seems to have a fillvalue of
-32.7680 for the UCUR variable 

The s1000 sample file (Avg_001.VTC.nc) on the other hand seems to have a
fillvalue of -3.27680

If exported as a NetCDF, one can see that the valid_min and valid_max values for
the UCUR variable are respectively -10 and 10.

So the repeated value of -3.27680 for the S1000 sample file ends up being in the
valid range, but I believe it should be a FillValue.

Is there a reason why the s500 and s1000 seem to output a different fillvalue? 

I don't have enough toolbox knowledge to know if this can be handled by the user in the metadata prior to the export